### PR TITLE
Update typehint on ZfcUser\Model\UserMetaInterface::setUser

### DIFF
--- a/src/ZfcUser/Model/UserMetaInterface.php
+++ b/src/ZfcUser/Model/UserMetaInterface.php
@@ -7,17 +7,17 @@ interface UserMetaInterface
     /**
      * Get user.
      *
-     * @return User
+     * @return UserInterface
      */
     public function getUser();
  
     /**
      * Set user.
      *
-     * @param User $user
+     * @param UserInterface $user
      * @return UserMeta
      */
-    public function setUser(User $user);
+    public function setUser(UserInterface $user);
  
     /**
      * Get metaKey.


### PR DESCRIPTION
The typehint on the `setUser` method don't match between `ZfcUser\Model\UserMeta` and `ZfcUser\Model\UserMetaInterface`, causing this error:

```
PHP Fatal error:  Declaration of ZfcUser\Model\UserMeta::setUser() must be compatible with that of ZfcUser\Model\UserMetaInterface::setUser() in /var/www/ZendSkeletonApplication/vendor/ZfcUser/src/ZfcUser/Model/UserMeta.php on line 13
```
