### PR TITLE
[#10] [#29] Updated database schema to use VARCHAR(45) as datatype for IP addresses

### DIFF
--- a/data/schema.sql
+++ b/data/schema.sql
@@ -6,9 +6,9 @@ CREATE TABLE user
     display_name  VARCHAR(50) DEFAULT NULL,
     password      VARCHAR(128) NOT NULL,
     last_login    DATETIME DEFAULT NULL,
-    last_ip       INTEGER DEFAULT NULL,
+    last_ip       VARCHAR(45) DEFAULT NULL,
     register_time DATETIME NOT NULL,
-    register_ip   INTEGER NOT NULL,
+    register_ip   VARCHAR(45) NOT NULL,
     active        TINYINT(1) NOT NULL,
     enabled       TINYINT(1) NOT NULL
 ) ENGINE=InnoDB;

--- a/data/schema.sqlite.sql
+++ b/data/schema.sqlite.sql
@@ -6,9 +6,9 @@ CREATE TABLE user
     display_name  VARCHAR(50) DEFAULT NULL,
     password      VARCHAR(128) NOT NULL,
     last_login    DATETIME DEFAULT NULL,
-    last_ip       INTEGER DEFAULT NULL,
+    last_ip       VARCHAR(45) DEFAULT NULL,
     register_time DATETIME NOT NULL,
-    register_ip   INTEGER NOT NULL,
+    register_ip   VARCHAR(45) NOT NULL,
     active        TINYINT(1) NOT NULL,
     enabled       TINYINT(1) NOT NULL
 );


### PR DESCRIPTION
This pull request solves the following issues:
- #10 - IPv6 IP address support
- #29 - IP address truncated on persist
- #41 - IP address truncated on persist

This patch changes the column datatype on IP address storage fields from `INTEGER` to `VARCHAR(45)` ([why 45?](http://stackoverflow.com/a/166157)).

This is the simplest fix for both issues.  The underlying issue is that [`ZfcUser\Model\UserMapper`](https://github.com/ZF-Commons/ZfcUser/blob/master/src/ZfcUser/Model/UserMapper.php#L19) uses [`ZfcBase\Mapper\DbMapperAbstract::toScalarValueArray`](https://github.com/ZF-Commons/ZfcBase/blob/master/src/ZfcBase/Mapper/DbMapperAbstract.php#L63), which does not call the `$long` argument of the IP getter methods, and so IP addresses are returned in dotted-decimal notation and not the numerical (`ip2long`) representation.

This will also need to be corrected in ZfcUserDoctrineORM (See [Pull Request 9](https://github.com/ZF-Commons/ZfcUserDoctrineORM/pull/9))
