### PR TITLE
Substitute Connection->getLastGeneratedId with Driver->getLastGeneratedValue

### DIFF
--- a/src/ZfcUser/Model/UserMapper.php
+++ b/src/ZfcUser/Model/UserMapper.php
@@ -22,7 +22,7 @@ class UserMapper extends DbMapperAbstract implements UserMapperInterface
             $this->getTableGateway()->update((array) $data, array($this->userIDField => $user->getUserId()));
         } else {
             $this->getTableGateway()->insert((array) $data);
-            $userId = $this->getTableGateway()->getAdapter()->getDriver()->getConnection()->getLastGeneratedId();
+            $userId = $this->getTableGateway()->getAdapter()->getDriver()->getLastGeneratedValue();
             $user->setUserId($userId);
         }
         return $user;


### PR DESCRIPTION
(See ZF Issue # ZF2-208)

```
Fatal error: Call to undefined method Zend\Db\Adapter\Driver\Pdo\Connection::getLastGeneratedId() in ZfcUser/Model/UserMapper.php on line 25
```
