### PR TITLE
Adding required classmap autoloading (because of Module.php) and fixing PSR-0 path

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,10 @@
     },
     "autoload": {
         "psr-0": {
-            "ZfcUser": "module/ZfcUser/src"
-        }
+            "ZfcUser": "src/"
+        },
+        "classmap": [
+            "./"
+        ]
     }
 }


### PR DESCRIPTION
PSR-0 path was not relative to package root, while classmap autoloading is required as `Module.php` doesn't respect PSR-0 standard.
