### PR TITLE
Change 'label' to 'value' on submit element in ZfcUser\Form\Base

### DIFF
--- a/src/ZfcUser/Form/Base.php
+++ b/src/ZfcUser/Form/Base.php
@@ -56,7 +56,7 @@ class Base extends ProvidesEventsForm
         $this->add(array(
             'name' => 'submit',
             'attributes' => array(
-                'label' => 'Submit',
+                'value' => 'Submit',
                 'type' => 'submit'
             ),
         ));


### PR DESCRIPTION
The submit element added via the base form uses 'label' instead of 'value', resulting in a label being added above the submit button on the register form:

![Preview of existing behavior](http://s.lundrigan.ca/8eb326.png)
