### PR TITLE
Remove underscore from messageTemplates variable in AbstractRecord

### DIFF
--- a/src/ZfcUser/Validator/AbstractRecord.php
+++ b/src/ZfcUser/Validator/AbstractRecord.php
@@ -16,7 +16,7 @@ abstract class AbstractRecord extends AbstractValidator
     /**
      * @var array Message templates
      */
-    protected $_messageTemplates = array(
+    protected $messageTemplates = array(
         self::ERROR_NO_RECORD_FOUND => "No record matching '%value%' was found",
         self::ERROR_RECORD_FOUND    => "A record matching '%value%' was found",
     );


### PR DESCRIPTION
The message templates variable was changed from `$_messageTemplates` to `$messageTemplates` in ZF2 [ce0bb6cc](https://github.com/zendframework/zf2/commit/ce0bb6cc0afa8274511adbef5d8feec5e1f5a3fb).  This results in the `NoRecordExists` and `RecordExists` validators in ZfcUser displaying an empty error message:

![](http://s.lundrigan.ca/6c1ea2.png)
