### PR TITLE
Update ClassMethods hydrator usage

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -127,7 +127,7 @@ class Module implements
                     $mapper->setDbAdapter($sm->get('zfcuser_zend_db_adapter'));
                     $entityClass = $options->getUserEntityClass();
                     $mapper->setEntityPrototype(new $entityClass);
-                    $mapper->setHydrator(new Mapper\UserHydrator(false));
+                    $mapper->setHydrator(new Mapper\UserHydrator());
                     return $mapper;
                 },
             ),


### PR DESCRIPTION
Update ClassMethods hydrator usage to reflect that it's default behavior is now to convert underscored array keys to camelCase

Change:  [5de7881](https://github.com/zendframework/zf2/commit/5de7881918556bc20093d4088209cf47b75edbfb)
Discussion: http://zend-framework-community.634137.n4.nabble.com/ClassMethods-hydrator-default-behavior-td4655628.html
