### PR TITLE
Update to redirect functionality

### DIFF
--- a/config/zfcuser.global.php.dist
+++ b/config/zfcuser.global.php.dist
@@ -126,6 +126,27 @@ $settings = array(
     //'use_redirect_parameter_if_present' => true,
 
     /**
+     * Login Redirect Route
+     * 
+     * Upon successful login the user will be redirected to the entered route
+     * 
+     * Default value: 'zfcuser'
+     * Accepted values: A valid route name within your application
+     * 
+     */
+    //'login_redirect_route' => 'zfcuser',
+    
+    /**
+     * Logout Redirect Route
+     *
+     * Upon logging out the user will be redirected to the enterd route
+     *
+     * Default value: 'zfcuser/login'
+     * Accepted values: A valid route name within your application
+     */
+    //'logout_redirect_route' => 'zfcuser/login',
+
+    /**
      * Password Security
      *
      * DO NOT CHANGE THE PASSWORD HASH SETTINGS FROM THEIR DEFAULTS

--- a/src/ZfcUser/Controller/UserController.php
+++ b/src/ZfcUser/Controller/UserController.php
@@ -89,7 +89,12 @@ class UserController extends AbstractActionController
     {
         $this->zfcUserAuthentication()->getAuthAdapter()->resetAdapters();
         $this->zfcUserAuthentication()->getAuthService()->clearIdentity();
-        return $this->redirect()->toRoute('zfcuser/login');
+        
+        if ($this->getOptions()->getUseRedirectParameterIfPresent() && $this->getRequest()->getPost()->get('redirect')) {
+            return $this->redirect()->toUrl($request->getPost()->get('redirect'));
+        }
+
+        return $this->redirect()->toRoute($this->getOptions()->getLogoutRedirectRoute());
     }
 
     /**
@@ -122,7 +127,7 @@ class UserController extends AbstractActionController
             return $this->redirect()->toUrl($request->getPost()->get('redirect'));
         }
 
-        return $this->redirect()->toRoute('zfcuser');
+        return $this->redirect()->toRoute($this->getOptions()->getLoginRedirectRoute());
     }
 
     /**

--- a/src/ZfcUser/Options/ModuleOptions.php
+++ b/src/ZfcUser/Options/ModuleOptions.php
@@ -19,6 +19,15 @@ class ModuleOptions extends AbstractOptions implements
     protected $useRedirectParameterIfPresent = true;
 
     /**
+     * @var string
+     */    
+    protected $loginRedirectRoute = 'zfcuser';
+    
+    /**
+     * @var string
+     */
+    protected $logoutRedirectRoute = 'zfcuser/login';
+    /**
      * @var int
      */
     protected $loginFormTimeout = 300;
@@ -79,6 +88,50 @@ class ModuleOptions extends AbstractOptions implements
             'timeout'    => 300,
         ),
     );
+
+    /**
+     * set login redirect route
+     *
+     * @param string $loginRedirectRoute
+     * @return ModuleOptions
+     */
+    public function setLoginRedirectRoute($loginRedirectRoute)
+    {
+    	$this->loginRedirectRoute = $loginRedirectRoute;
+    	return $this;
+    }
+    
+    /**
+     * get login redirect route
+     *
+     * @return string
+     */
+    public function getLoginRedirectRoute()
+    {
+    	return $this->loginRedirectRoute;
+    }
+    
+    /**
+     * set logout redirect route
+     *
+     * @param string $logoutRedirectRoute
+     * @return ModuleOptions
+     */    
+    public function setLogoutRedirectRoute($logoutRedirectRoute)
+    {
+    	$this->logoutRedirectRoute = $logoutRedirectRoute;
+    	return $this;
+    }
+
+    /**
+     * get logout redirect route
+     *
+     * @return string
+     */    
+    public function getLogoutRedirectRoute()
+    {
+    	return $this->logoutRedirectRoute;
+    }
 
     /**
      * set use redirect param if present


### PR DESCRIPTION
Added a configuration option to specify a route to be used to redirect
the user to when they have successfully logged in or out. A default
value is specified in the ModuleOptions.php file. The user will be able
to specify a route in the zfcuser.global.php.dist.

There is another part to this redirect feature which needs some work and
that involves a query string parameter. This way a user could specify a
route for that particular login to over ride the route specified in the
config.
