### PR TITLE
Add triggering of register.post event to user service

### DIFF
--- a/src/ZfcUser/Service/User.php
+++ b/src/ZfcUser/Service/User.php
@@ -79,6 +79,7 @@ class User extends EventProvider implements ServiceManagerAwareInterface
         }
         $this->getEventManager()->trigger(__FUNCTION__, $this, array('user' => $user, 'form' => $form));
         $this->getUserMapper()->insert($user);
+        $this->getEventManager()->trigger(__FUNCTION__.'.post', $this, array('user' => $user, 'form' => $form));
         return $user;
     }
 


### PR DESCRIPTION
Allows performing post-registration tasks which require the user id field be populated in the entity. 
