### PR TITLE
fixed wrong setting of the label of form submit elements

### DIFF
--- a/src/ZfcUser/Form/Login.php
+++ b/src/ZfcUser/Form/Login.php
@@ -59,8 +59,8 @@ class Login extends ProvidesEventsForm
 
         $submitElement = new Element\Button('submit');
 
+        $submitElement->setLabel('Sign In');
         $submitElement->setAttributes(array(
-            'label' => 'Sign In',
             'type'  => 'submit',
         ));
 

--- a/src/ZfcUser/Form/Register.php
+++ b/src/ZfcUser/Form/Register.php
@@ -33,7 +33,7 @@ class Register extends Base
         if ($this->getRegistrationOptions()->getUseRegistrationFormCaptcha() && $this->captchaElement) {
             $this->add($this->captchaElement, array('name'=>'captcha'));
         }
-        $this->get('submit')->setAttribute('label', 'Register');
+        $this->get('submit')->setLabel('Register');
         $this->getEventManager()->trigger('init', $this);
     }
 


### PR DESCRIPTION
The form class was trying to set the label of submit buttons by setting its attributes, where there's no html attribute for label. 
It is now using the setLabel method.
