### PR TITLE
Only verify current password if credential field exists.

### DIFF
--- a/src/ZfcUser/Service/User.php
+++ b/src/ZfcUser/Service/User.php
@@ -102,13 +102,13 @@ class User extends EventProvider implements ServiceManagerAwareInterface
         $newPass = $data['newCredential'];
 
         if (array_key_exists('credential', $data)) {
-          $oldPass = $data['credential'];
+            $oldPass = $data['credential'];
 
-          $bcrypt->setCost($this->getOptions()->getPasswordCost());
+            $bcrypt->setCost($this->getOptions()->getPasswordCost());
 
-          if (!$bcrypt->verify($oldPass, $currentUser->getPassword())) {
-              return false;
-          }
+            if (!$bcrypt->verify($oldPass, $currentUser->getPassword())) {
+                return false;
+            }
         }
 
         $pass = $bcrypt->create($newPass);


### PR DESCRIPTION
Current service does not allow you to remove credential from the form.

This fix allows you to remove credential, but still forces the most secure option.  To completely remove credential, you also need to use a custom filter to replace ZfcUser\Form\ChangePasswordFilter
