### PR TITLE
User states

### DIFF
--- a/config/zfcuser.global.php.dist
+++ b/config/zfcuser.global.php.dist
@@ -170,6 +170,30 @@ $settings = array(
     //'password_cost' => 14,
 
     /**
+     * Enable user state usage
+     * 
+     * Should user's state be used in the registration/login process?
+     */
+    //'enable_user_state' => true,
+    
+    /**
+     * Default user state upon registration
+     * 
+     * What state user should have upon registration?
+     * Allowed value type: integer
+     */
+    //'default_user_state' => 1,
+    
+    /**
+     * States which are allowing user to login
+     * 
+     * When user tries to login, is his/her state one of the following?
+     * Include null if you want user's with no state to login as well.
+     * Allowed value types: null and integer
+     */
+    //'allowed_login_states' => array( null, 1 ),
+    
+    /**
      * End of ZfcUser configuration
      */
 );

--- a/data/schema.sql
+++ b/data/schema.sql
@@ -4,5 +4,6 @@ CREATE TABLE user
     username      VARCHAR(255) DEFAULT NULL UNIQUE,
     email         VARCHAR(255) DEFAULT NULL UNIQUE,
     display_name  VARCHAR(50) DEFAULT NULL,
-    password      VARCHAR(128) NOT NULL
+    password      VARCHAR(128) NOT NULL,
+    state         SMALLINT
 ) ENGINE=InnoDB;

--- a/data/schema.sqlite.sql
+++ b/data/schema.sqlite.sql
@@ -4,5 +4,6 @@ CREATE TABLE user
     username      VARCHAR(255) DEFAULT NULL UNIQUE,
     email         VARCHAR(255) DEFAULT NULL UNIQUE,
     display_name  VARCHAR(50) DEFAULT NULL,
-    password      VARCHAR(128) NOT NULL
+    password      VARCHAR(128) NOT NULL,
+    state         SMALLINT
 );

--- a/src/ZfcUser/Authentication/Adapter/Db.php
+++ b/src/ZfcUser/Authentication/Adapter/Db.php
@@ -68,7 +68,17 @@ class Db extends AbstractAdapter implements ServiceManagerAwareInterface
             $this->setSatisfied(false);
             return false;
         }
-
+        
+        if ($this->getOptions()->getEnableUserState()) {
+            // Don't allow user to login if state is not in allowed list
+            if (!in_array($userObject->getState(), $this->getOptions()->getAllowedLoginStates())) {
+                $e->setCode(AuthenticationResult::FAILURE_INACTIVE)
+                  ->setMessages(array('A record with the supplied identity is not active.'));
+                $this->setSatisfied(false);
+                return false;
+            }
+        }
+        
         $bcrypt = new Bcrypt();
         $bcrypt->setCost($this->getOptions()->getPasswordCost());
         if (!$bcrypt->verify($credential,$userObject->getPassword())) {

--- a/src/ZfcUser/Entity/User.php
+++ b/src/ZfcUser/Entity/User.php
@@ -28,6 +28,11 @@ class User implements UserInterface
      * @var string
      */
     protected $password;
+    
+    /**
+     * @var int
+     */
+    protected $state;
 
     /**
      * Get id.
@@ -136,6 +141,28 @@ class User implements UserInterface
     public function setPassword($password)
     {
         $this->password = $password;
+        return $this;
+    }
+    
+    /**
+     * Get state.
+     *
+     * @return int
+     */
+    public function getState()
+    {
+        return $this->state;
+    }
+
+    /**
+     * Set state.
+     *
+     * @param int $state
+     * @return UserInterface
+     */
+    public function setState($state)
+    {
+        $this->state = $state;
         return $this;
     }
 }

--- a/src/ZfcUser/Entity/UserInterface.php
+++ b/src/ZfcUser/Entity/UserInterface.php
@@ -78,4 +78,20 @@ interface UserInterface
      * @return UserInterface
      */
     public function setPassword($password);
+    
+    /**
+     * Get state.
+     *
+     * @return int
+     */
+    public function getState();
+
+    /**
+     * Set state.
+     *
+     * @param int $state
+     * @return UserInterface
+     */
+    public function setState($state);
+
 }

--- a/src/ZfcUser/Options/ModuleOptions.php
+++ b/src/ZfcUser/Options/ModuleOptions.php
@@ -44,6 +44,21 @@ class ModuleOptions extends AbstractOptions implements
     protected $loginAfterRegistration = true;
 
     /**
+     * @var int
+     */
+    protected $enableUserState = false;
+            
+    /**
+     * @var int
+     */
+    protected $defaultUserState = 1;
+
+    /**
+     * @var Array
+     */
+    protected $allowedLoginStates = array( null, 1 );
+    
+    /**
      * @var array
      */
     protected $authIdentityFields = array( 'email' );
@@ -244,6 +259,72 @@ class ModuleOptions extends AbstractOptions implements
         return $this->loginAfterRegistration;
     }
 
+    /**
+     * get user state usage for registration/login process
+     *
+     * @return int
+     */
+    public function getEnableUserState()
+    {
+        return $this->enableUserState;
+    }
+    
+    /**
+     * set user state usage for registration/login process
+     *
+     * @param boolean $flag
+     * @return ModuleOptions
+     */
+    public function setEnableUserState($flag)
+    {
+        $this->enableUserState = $flag;
+        return $this;
+    }
+    
+    /**
+     * get default user state on registration
+     *
+     * @return int
+     */
+    public function getDefaultUserState()
+    {
+        return $this->defaultUserState;
+    }
+    
+    /**
+     * set default user state on registration
+     *
+     * @param int $state
+     * @return ModuleOptions
+     */
+    public function setDefaultUserState($state)
+    {
+        $this->defaultUserState = $state;
+        return $this;
+    }
+
+    /**
+     * get list of states to allow user login
+     *
+     * @return int
+     */
+    public function getAllowedLoginStates()
+    {
+        return $this->allowedLoginStates;
+    }
+    
+    /**
+     * set list of states to allow user login
+     *
+     * @param Array $states
+     * @return ModuleOptions
+     */
+    public function setAllowedLoginStates(Array $states)
+    {
+        $this->allowedLoginStates = $states;
+        return $this;
+    }
+    
     /**
      * set auth identity fields
      *

--- a/src/ZfcUser/Service/User.php
+++ b/src/ZfcUser/Service/User.php
@@ -82,6 +82,13 @@ class User extends EventProvider implements ServiceManagerAwareInterface
         if ($this->getOptions()->getEnableDisplayName()) {
             $user->setDisplayName($data['display_name']);
         }
+        
+        // If user state is enabled, set the default state value
+        if ($this->getOptions()->getEnableUserState()) {
+            if ($this->getOptions()->getDefaultUserState()) {
+                $user->setState($this->getOptions()->getDefaultUserState());
+            }
+        }
         $this->getEventManager()->trigger(__FUNCTION__, $this, array('user' => $user, 'form' => $form));
         $this->getUserMapper()->insert($user);
         $this->getEventManager()->trigger(__FUNCTION__.'.post', $this, array('user' => $user, 'form' => $form));


### PR DESCRIPTION
Changes made to support user states on registration and login process. Default user state is 1 and allowed states in order to login by default are null and 1.

Usage of user states must be enabled in the configuration, and allowed states for login are customizable with an array. Also, a default user state upon registration is also configurable.

Database changes: One new column 'state' of type smallint.
