### PR TITLE
Fixed how Form\Base deals with captcha options

### DIFF
--- a/src/ZfcUser/Form/Base.php
+++ b/src/ZfcUser/Form/Base.php
@@ -68,9 +68,7 @@ class Base extends ProvidesEventsForm
                 'type' => 'Zend\Form\Element\Captcha',
                 'options' => array(
                     'label' => 'Please type the following text',
-                ),
-                'attributes' => array(
-                    'captcha' => $this->getOptions()->getFormCaptchaOptions(),
+                    'captcha' => $this->getRegistrationOptions()->getFormCaptchaOptions(),
                 ),
             ));
         }


### PR DESCRIPTION
Base\Form was setting the captcha options as "attributes" rather than options. This did not actually produce a captcha in the form, but an error. Also, the form was looking for the options via "getOptions" rather than the correct "getRegistrationOptions". 
