### PR TITLE
Add travis CI configuration file for CS

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,10 @@
+<?php
+$finder = Symfony\CS\Finder\DefaultFinder::create()
+    ->name('*.phtml')
+    ->notName('autoload_classmap.php')
+    ->notName('README.md')
+    ->notName('.php_cs')
+    ->in(__DIR__);
+
+return Symfony\CS\Config\Config::create()
+    ->finder($finder);

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: php
+
+php:
+  - 5.3.3
+  - 5.3
+  - 5.4
+
+before_install:
+  - wget http://cs.sensiolabs.org/get/php-cs-fixer.phar
+
+script:
+  - output=$(php php-cs-fixer.phar fix -v --dry-run --level=psr2 .); if [[ $output ]]; then while read -r line; do echo -e "\e[00;31m$line\e[00m"; done <<< "$output"; false; fi;


### PR DESCRIPTION
Until we have unit tests, we can already check coding standards
automatically with Travis CI and PHP-CS-FIXER.
