### PR TITLE
Made Captcha use more generic and Fixed Captcha implementation

### DIFF
--- a/config/zfcuser.global.php.dist
+++ b/config/zfcuser.global.php.dist
@@ -98,7 +98,7 @@ $settings = array(
      * Determines if a captcha should be utilized on the user registration form.
      * Default value is false.
      */
-    //'use_registration_form_captcha' => false,
+    //'use_form_captcha' => false,
 
     /**
      * Form Captcha Options
@@ -108,7 +108,7 @@ $settings = array(
      * pass to it. The default uses the Figlet captcha.
      */
     /*'form_captcha_options' => array(
-        'class'   => 'figlet',
+        'class'   => 'Zend\Captcha\Figlet',
         'options' => array(
             'wordLen'    => 5,
             'expiration' => 300,

--- a/src/ZfcUser/Form/Base.php
+++ b/src/ZfcUser/Form/Base.php
@@ -62,15 +62,13 @@ class Base extends ProvidesEventsForm
             ),
         ));
 
-        if ($this->getRegistrationOptions()->getUseRegistrationFormCaptcha()) {
+        if ($this->getFormOptions()->getUseFormCaptcha()) {
             $this->add(array(
                 'name' => 'captcha',
                 'type' => 'Zend\Form\Element\Captcha',
                 'options' => array(
                     'label' => 'Please type the following text',
-                ),
-                'attributes' => array(
-                    'captcha' => $this->getOptions()->getFormCaptchaOptions(),
+                    'captcha' => $this->getFormOptions()->getFormCaptchaOptions(),
                 ),
             ));
         }

--- a/src/ZfcUser/Form/Register.php
+++ b/src/ZfcUser/Form/Register.php
@@ -20,17 +20,17 @@ class Register extends Base
      */
     public function __construct($name = null, RegistrationOptionsInterface $options)
     {
-        $this->setRegistrationOptions($options);
+        $this->setFormOptions($options);
         parent::__construct($name);
 
         $this->remove('userId');
-        if (!$this->getRegistrationOptions()->getEnableUsername()) {
+        if (!$this->getFormOptions()->getEnableUsername()) {
             $this->remove('username');
         }
-        if (!$this->getRegistrationOptions()->getEnableDisplayName()) {
+        if (!$this->getFormOptions()->getEnableDisplayName()) {
             $this->remove('display_name');
         }
-        if ($this->getRegistrationOptions()->getUseRegistrationFormCaptcha() && $this->captchaElement) {
+        if ($this->getFormOptions()->getUseFormCaptcha() && $this->captchaElement) {
             $this->add($this->captchaElement, array('name'=>'captcha'));
         }
         $this->get('submit')->setLabel('Register');
@@ -43,23 +43,23 @@ class Register extends Base
     }
 
     /**
-     * Set Regsitration Options
+     * Set Registration Options
      *
      * @param RegistrationOptionsInterface $registrationOptions
      * @return Register
      */
-    public function setRegistrationOptions(RegistrationOptionsInterface $registrationOptions)
+    public function setFormOptions(RegistrationOptionsInterface $registrationOptions)
     {
         $this->registrationOptions = $registrationOptions;
         return $this;
     }
 
     /**
-     * Get Regsitration Options
+     * Get Registration Options
      *
      * @return RegistrationOptionsInterface
      */
-    public function getRegistrationOptions()
+    public function getFormOptions()
     {
         return $this->registrationOptions;
     }

--- a/src/ZfcUser/Options/ModuleOptions.php
+++ b/src/ZfcUser/Options/ModuleOptions.php
@@ -343,7 +343,7 @@ class ModuleOptions extends AbstractOptions implements
      * @param bool $useRegistrationFormCaptcha
      * @return ModuleOptions
      */
-    public function setUseRegistrationFormCaptcha($useRegistrationFormCaptcha)
+    public function setUseFormCaptcha($useRegistrationFormCaptcha)
     {
         $this->useRegistrationFormCaptcha = $useRegistrationFormCaptcha;
         return $this;
@@ -354,7 +354,7 @@ class ModuleOptions extends AbstractOptions implements
      *
      * @return bool
      */
-    public function getUseRegistrationFormCaptcha()
+    public function getUseFormCaptcha()
     {
         return $this->useRegistrationFormCaptcha;
     }

--- a/src/ZfcUser/Options/RegistrationOptionsInterface.php
+++ b/src/ZfcUser/Options/RegistrationOptionsInterface.php
@@ -68,14 +68,14 @@ interface RegistrationOptionsInterface
      * @param bool $useRegistrationFormCaptcha
      * @return ModuleOptions
      */
-    public function setUseRegistrationFormCaptcha($useRegistrationFormCaptcha);
+    public function setUseFormCaptcha($useRegistrationFormCaptcha);
 
     /**
      * get use a captcha in registration form
      *
      * @return bool
      */
-    public function getUseRegistrationFormCaptcha();
+    public function getUseFormCaptcha();
 
     /**
      * set login after registration


### PR DESCRIPTION
Captcha was not working as the Captcha options where not passed to the options.
Replace useRegistrationFormCaptcha with useFormCaptcha to make the method naming more generic for further implementations in custom modules. e.g. ZfcUserAdmin.
