### PR TITLE
Refactore Plugin Controller ZfcUserAuthentication

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -148,4 +148,23 @@ class Module implements
             ),
         );
     }
+    /**
+     * New Controller Plugin integration.
+     * No more Dependency with the service manager
+     * @return array
+     */
+    public function getControllerPluginConfig() {
+        return array(
+            'factories' => array(
+                'zfcuserauthentication' => function($sm) {
+                    $instance = new Controller\Plugin\ZfcUserAuthentication();
+                    $adapterChain = $sm->getServiceLocator()->get('ZfcUser\Authentication\Adapter\AdapterChain');
+                    $zfcuser_auth_service = $sm->getServiceLocator()->get('zfcuser_auth_service');
+                    $instance->setAuthAdapter($adapterChain);
+                    $instance->setAuthService($zfcuser_auth_service);
+                    return $instance;
+                },
+            ),
+        );
+    }
 }

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -10,11 +10,6 @@ return array(
             'zfcuser' => 'ZfcUser\Controller\UserController',
         ),
     ),
-    'controller_plugins' => array(
-        'invokables' => array(
-            'zfcuserauthentication' => 'ZfcUser\Controller\Plugin\ZfcUserAuthentication',
-        ),
-    ),
     'service_manager' => array(
         'aliases' => array(
             'zfcuser_zend_db_adapter' => 'Zend\Db\Adapter\Adapter',

--- a/src/ZfcUser/Controller/Plugin/ZfcUserAuthentication.php
+++ b/src/ZfcUser/Controller/Plugin/ZfcUserAuthentication.php
@@ -4,11 +4,9 @@ namespace ZfcUser\Controller\Plugin;
 
 use Zend\Mvc\Controller\Plugin\AbstractPlugin;
 use Zend\Authentication\AuthenticationService;
-use Zend\ServiceManager\ServiceManagerAwareInterface;
-use Zend\ServiceManager\ServiceManager;
 use ZfcUser\Authentication\Adapter\AdapterChain as AuthAdapter;
 
-class ZfcUserAuthentication extends AbstractPlugin implements ServiceManagerAwareInterface
+class ZfcUserAuthentication extends AbstractPlugin 
 {
     /**
      * @var AuthAdapter
@@ -53,7 +51,7 @@ class ZfcUserAuthentication extends AbstractPlugin implements ServiceManagerAwar
     public function getAuthAdapter()
     {
         if (null === $this->authAdapter) {
-            $this->authAdapter = $this->getServiceManager()->get('ZfcUser\Authentication\Adapter\AdapterChain');
+            throw new \Exception('AuthAdapter has not been set!');
         }
         return $this->authAdapter;
     }
@@ -77,7 +75,7 @@ class ZfcUserAuthentication extends AbstractPlugin implements ServiceManagerAwar
     public function getAuthService()
     {
         if (null === $this->authService) {
-            $this->authService = $this->getServiceManager()->get('zfcuser_auth_service');
+            throw new \Exception('authService has not been set!');
         }
         return $this->authService;
     }
@@ -91,26 +89,5 @@ class ZfcUserAuthentication extends AbstractPlugin implements ServiceManagerAwar
     {
         $this->authService = $authService;
         return $this;
-    }
-
-    /**
-     * Retrieve service manager instance
-     *
-     * @return ServiceManager
-     */
-    public function getServiceManager()
-    {
-        return $this->serviceManager->getServiceLocator();
-    }
-
-    /**
-     * Set service manager instance
-     *
-     * @param ServiceManager $locator
-     * @return void
-     */
-    public function setServiceManager(ServiceManager $serviceManager)
-    {
-        $this->serviceManager = $serviceManager;
     }
 }


### PR DESCRIPTION
Hi

I could not get the ServiceManager in ZfcUserAuthentication:

**Fatal error: _Call to a member function getServiceLocator() on a non-object_ in [...]\vendor\zf-commons\zfc-user\src\ZfcUser\Controller\Plugin\ZfcUserAuthentication.php on line 103**

So I found this way to refactore the plugin, and then I cut the dependency with the serviceManager ( and serviceLocator)

Just discover this pull request... ZF-Commons/ZfcUser#159 ,it is almost the same.
