### PR TITLE
Allow custom register form hydrator

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -6,6 +6,7 @@ use Zend\ModuleManager\ModuleManager;
 use Zend\ModuleManager\Feature\AutoloaderProviderInterface;
 use Zend\ModuleManager\Feature\ConfigProviderInterface;
 use Zend\ModuleManager\Feature\ServiceProviderInterface;
+use Zend\Stdlib\Hydrator\ClassMethods;
 
 class Module implements
     AutoloaderProviderInterface,
@@ -116,6 +117,10 @@ class Module implements
                     $form = new Form\ChangePassword(null, $sm->get('zfcuser_module_options'));
                     $form->setInputFilter(new Form\ChangePasswordFilter($options));
                     return $form;
+                },
+
+                'zfcuser_register_form_hydrator' => function ($sm) {
+                    return new ClassMethods();
                 },
 
                 'zfcuser_change_email_form' => function($sm) {

--- a/src/ZfcUser/Service/User.php
+++ b/src/ZfcUser/Service/User.php
@@ -6,7 +6,6 @@ use Zend\Authentication\AuthenticationService;
 use Zend\Form\Form;
 use Zend\ServiceManager\ServiceManagerAwareInterface;
 use Zend\ServiceManager\ServiceManager;
-use Zend\Stdlib\Hydrator\ClassMethods;
 use Zend\Crypt\Password\Bcrypt;
 use ZfcBase\EventManager\EventProvider;
 use ZfcUser\Mapper\UserInterface as UserMapperInterface;
@@ -62,7 +61,7 @@ class User extends EventProvider implements ServiceManagerAwareInterface
         $class = $this->getOptions()->getUserEntityClass();
         $user  = new $class;
         $form  = $this->getRegisterForm();
-        $form->setHydrator(new ClassMethods());
+        $form->setHydrator($this->getServiceManager()->get('zfcuser_register_form_hydrator'));
         $form->bind($user);
         $form->setData($data);
         if (!$form->isValid()) {
@@ -82,7 +81,7 @@ class User extends EventProvider implements ServiceManagerAwareInterface
         if ($this->getOptions()->getEnableDisplayName()) {
             $user->setDisplayName($data['display_name']);
         }
-        
+
         // If user state is enabled, set the default state value
         if ($this->getOptions()->getEnableUserState()) {
             if ($this->getOptions()->getDefaultUserState()) {


### PR DESCRIPTION
In the register form, if the validation fail and you are using a custom entity, with method like

``` php
public function getFoobar($name) {

}
```

The ClassMethods Hydrator cause an error, because $name is not passed.

This pr should allow to defined another hydrator for the register form.
