### PR TITLE
Translation of the validation messages for AbstractRecord

### DIFF
--- a/src/ZfcUser/Validator/AbstractRecord.php
+++ b/src/ZfcUser/Validator/AbstractRecord.php
@@ -17,8 +17,8 @@ abstract class AbstractRecord extends AbstractValidator
      * @var array Message templates
      */
     protected $messageTemplates = array(
-        self::ERROR_NO_RECORD_FOUND => "No record matching '%value%' was found",
-        self::ERROR_RECORD_FOUND    => "A record matching '%value%' was found",
+        self::ERROR_NO_RECORD_FOUND => "No record matching the input was found",
+        self::ERROR_RECORD_FOUND    => "A record matching the input was found",
     );
 
     /**


### PR DESCRIPTION
The validation messages have been modified in ZF2 3 months ago (zendframework/zf2@e422a20 ) but haven't been modified in ZfcUser yet.
