### PR TITLE
Fix error because of undefined class constant in src/ZfcUser/Authentication/Adapter/Db.php

### DIFF
--- a/src/ZfcUser/Authentication/Adapter/Db.php
+++ b/src/ZfcUser/Authentication/Adapter/Db.php
@@ -72,7 +72,7 @@ class Db extends AbstractAdapter implements ServiceManagerAwareInterface
         if ($this->getOptions()->getEnableUserState()) {
             // Don't allow user to login if state is not in allowed list
             if (!in_array($userObject->getState(), $this->getOptions()->getAllowedLoginStates())) {
-                $e->setCode(AuthenticationResult::FAILURE_INACTIVE)
+                $e->setCode(AuthenticationResult::FAILURE_UNCATEGORIZED)
                   ->setMessages(array('A record with the supplied identity is not active.'));
                 $this->setSatisfied(false);
                 return false;


### PR DESCRIPTION
Fix for issue #198.

The used constant was not defined in the AuthenticationResult so I changed an uncategorized error.
