### PR TITLE
make use of custom Hydrator

### DIFF
--- a/src/ZfcUser/Mapper/User.php
+++ b/src/ZfcUser/Mapper/User.php
@@ -5,6 +5,7 @@ namespace ZfcUser\Mapper;
 use ZfcBase\Mapper\AbstractDbMapper;
 use ZfcUser\Entity\UserInterface as UserEntityInterface;
 use Zend\Stdlib\Hydrator\HydratorInterface;
+use ZfcBase\Mapper\UserHydrator;
 
 class User extends AbstractDbMapper implements UserInterface
 {
@@ -39,9 +40,19 @@ class User extends AbstractDbMapper implements UserInterface
         $this->getEventManager()->trigger('find', $this, array('entity' => $entity));
         return $entity;
     }
+    
+    protected $hydrator;
+    
+    public function getHydrator(){
+    	if (!isset($this->hydrator)){
+    		$this->hydrator=new UserHydrator();    		
+    	}
+    	return $this->hydrator;
+    }
 
     public function insert($entity, $tableName = null, HydratorInterface $hydrator = null)
     {
+    	if ($hydrator==null) $hydrator=$this->getHydrator();
         $result = parent::insert($entity, $tableName, $hydrator);
         $entity->setId($result->getGeneratedValue());
         return $result;
@@ -49,10 +60,14 @@ class User extends AbstractDbMapper implements UserInterface
 
     public function update($entity, $where = null, $tableName = null, HydratorInterface $hydrator = null)
     {
+    	if ($hydrator==null) $hydrator=$this->getHydrator();
+    	
         if (!$where) {
             $where = 'user_id = ' . $entity->getId();
         }
 
         return parent::update($entity, $where, $tableName, $hydrator);
     }
+    
+
 }

--- a/src/ZfcUser/Mapper/UserHydrator.php
+++ b/src/ZfcUser/Mapper/UserHydrator.php
@@ -19,10 +19,14 @@ class UserHydrator extends ClassMethods
         if (!$object instanceof UserEntityInterface) {
             throw new Exception\InvalidArgumentException('$object must be an instance of ZfcUser\Entity\UserInterface');
         }
-        /* @var $object UserInterface*/
-        $data = parent::extract($object);
-        $data = $this->mapField('id', 'user_id', $data);
-        return $data;
+        if (method_exists($object, 'toArray')){
+            return  $object->toArray();
+        }else{
+            /* @var $object UserInterface*/
+            $data = parent::extract($object);
+            $data = $this->mapField('id', 'user_id', $data);
+            return $data;
+        }
     }
 
     /**


### PR DESCRIPTION
The default implementation of the ZfcUser\Mapper\User use AbstractDbMapper's default Hydrator, i.e. ClassMethods. If a custom User object implement an interface such as ServiceManagerAwareInterface, it will has a getServiceManager() method that cannot be converted into string by Zend\Db\Adapter\Driver\Pdo\Statement::Zend\Db\Adapter\Driver\Pdo().

I think the Mapper should allows the User object to explicitly how its data is extracted/hydrated.
