### PR TITLE
Registration redirect not working after an unsuccessful registration attempt

### DIFF
--- a/src/ZfcUser/Controller/UserController.php
+++ b/src/ZfcUser/Controller/UserController.php
@@ -182,6 +182,8 @@ class UserController extends AbstractActionController
         $post = $prg;
         $user = $service->register($post);
 
+        $redirect = isset($prg['redirect']) ? $prg['redirect'] : null;
+
         if (!$user) {
             return array(
                 'registerForm' => $form,


### PR DESCRIPTION
What was happening was that, after a failed registration a null $redirect variable was being passed to the ViewModel. This was because $redirect variable was set from the get query which didn't exist after the pgr, instead the redirect url should have been set from the prg array if set.
