### PR TITLE
Fix global config path in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Options
 
 The ZfcUser module has some options to allow you to quickly customize the basic
 functionality. After installing ZfcUser, copy
-`./vendor/ZfcUser/config/zfcuser.global.php.dist` to
+`./vendor/zf-commons/zfc-user/config/zfcuser.global.php.dist` to
 `./config/autoload/zfcuser.global.php` and change the values as desired.
 
 The following options are available:


### PR DESCRIPTION
The original path for the global config to be copied is NOT where composer would put the file, this pr fixes that with the right path.
