### PR TITLE
Removed the dev master require for zfcbase

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ Installation
 
     ```json
     "require": {
-        "zf-commons/zfc-base": "dev-master",
         "zf-commons/zfc-user": "dev-master"
     }
     ```


### PR DESCRIPTION
As having both zfcuser and zfcbase on dev-master require causes dependency problems and seeing that installing zfcuser dev-master installs an appropriate version of zfcbase is make sense to not have zfcbase as a require
