### PR TITLE
fix registration when not allowed

### DIFF
--- a/src/ZfcUser/Controller/UserController.php
+++ b/src/ZfcUser/Controller/UserController.php
@@ -156,7 +156,11 @@ class UserController extends AbstractActionController
             // redirect to the login redirect route
             return $this->redirect()->toRoute($this->getOptions()->getLoginRedirectRoute());
         }
-
+        // if registration is disabled
+        if (!$this->getOptions()->getEnableRegistration()) {
+            return array('enableRegistration' => false);
+        }
+        
         $request = $this->getRequest();
         $service = $this->getUserService();
         $form = $this->getRegisterForm();


### PR DESCRIPTION
The view was the only place where was checked if registration was
disabled. Sending post data would still register a new user.
