### PR TITLE
Removed Deprecated Query route configuration (ZF2013-01)

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -77,13 +77,7 @@ return array(
                                 'controller' => 'zfcuser',
                                 'action'     => 'changepassword',
                             ),
-                        ),
-                        'may_terminate' => true,
-                        'child_routes' => array(
-                            'query' => array(
-                                'type' => 'Query',
-                            ),
-                        ),
+                        ),                        
                     ),
                     'changeemail' => array(
                         'type' => 'Literal',
@@ -93,13 +87,7 @@ return array(
                                 'controller' => 'zfcuser',
                                 'action' => 'changeemail',
                             ),
-                        ),
-                        'may_terminate' => true,
-                        'child_routes' => array(
-                            'query' => array(
-                                'type' => 'Query',
-                            ),
-                        ),
+                        ),                        
                     ),
                 ),
             ),


### PR DESCRIPTION
Removed deprecated Query route configuration for changemail and changepassword routes. FROM ZF2013-01: Route Parameter Injection Via Query String in Zend\Mvc
