### PR TITLE
Ability to use different kind of hydrator with user registration form:  zfcuser_register_form_hydrator

### DIFF
--- a/src/ZfcUser/Service/User.php
+++ b/src/ZfcUser/Service/User.php
@@ -295,7 +295,7 @@ class User extends EventProvider implements ServiceManagerAwareInterface
      */
     public function getFormHydrator()
     {
-        if (!$this->formHydrator instanceof Hydrator\ClassMethods) {
+        if (!$this->formHydrator instanceof Hydrator\HydratorInterface) {
             $this->setFormHydrator($this->getServiceManager()->get('zfcuser_register_form_hydrator'));
         }
 
@@ -305,10 +305,10 @@ class User extends EventProvider implements ServiceManagerAwareInterface
     /**
      * Set the Form Hydrator to use
      *
-     * @param Hydrator\ClassMethods $formHydrator
+     * @param Hydrator\HydratorInterface $formHydrator
      * @return User
      */
-    public function setFormHydrator(Hydrator\AbstractHydrator $formHydrator)
+    public function setFormHydrator(Hydrator\HydratorInterface $formHydrator)
     {
         $this->formHydrator = $formHydrator;
         return $this;


### PR DESCRIPTION
Using AbstractHydrator is possible to use other
zfcuser_register_form_hydrator for example:
DoctrineModule\Stdlib\Hydrator\DoctrineObject
