### PR TITLE
Getting already stored data twice

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -139,7 +139,7 @@ class Module implements
 
                 'zfcuser_change_email_form' => function($sm) {
                     $options = $sm->get('zfcuser_module_options');
-                    $form = new Form\ChangeEmail(null, $sm->get('zfcuser_module_options'));
+                    $form = new Form\ChangeEmail(null, $options);
                     $form->setInputFilter(new Form\ChangeEmailFilter(
                         $options,
                         new Validator\NoRecordExists(array(


### PR DESCRIPTION
Since the $sm->get('zfcuser_module_options') is already stored in the $options variable, there is no reason to call it again in line 142.
