### PR TITLE
Added alias to allow reasonable version to be included.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,12 @@
             "homepage": "http://www.spiffyjr.me/"
         }
     ],
+    {
+    "extra": {
+        "branch-alias": {
+            "dev-master": "0.1.x-dev"
+        }
+    },
     "require": {
         "php": ">=5.3.3",
         "zendframework/zend-authentication": "~2.1",


### PR DESCRIPTION
Apparently some people requiring "zf-commons/zfc-user": "dev-master", are getting an old version:
http://stackoverflow.com/questions/17555158/composer-fail-update-zfc-user-doctrine-orm
