### PR TITLE
New Login Authenticate Events

### DIFF
--- a/src/ZfcUser/Authentication/Adapter/AdapterChain.php
+++ b/src/ZfcUser/Authentication/Adapter/AdapterChain.php
@@ -69,9 +69,11 @@ class AdapterChain extends EventProvider implements AdapterInterface
         }
 
         if ($e->getIdentity()) {
+            $this->getEventManager()->trigger('authenticate.success', $e);
             return true;
         }
 
+        $this->getEventManager()->trigger('authenticate.fail', $e);
         return false;
     }
 


### PR DESCRIPTION
Added two new events surrounding the authentication, which will fire after the authentication, but before the redirect.

These are:

authenticate.success
authenticate.fail
