### PR TITLE
Remove extra trailing comma that causes an error when updating via composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
             "homepage": "http://www.spiffyjr.me/"
         }
     ],
-    {
     "extra": {
         "branch-alias": {
             "dev-master": "0.1.x-dev"


### PR DESCRIPTION
Here's the error message and composer update is ran:

> Loading composer repositories with package information
> Reading composer.json of https://github.com/ZF-Commons/ZfcUser (master)  
> Skipped branch master, "https://api.github.com/repos/ZF-Commons/ZfcUser/contents/composer.json?ref=8835f64cf469c1fb8e5ff887f530028ca48a6c48" does not contain valid JSON
> Parse error on line 20:
> ...       }    ],    {    "extra": {  
> ---------------------^
> Expected: 'STRING' - It appears you have an extra trailing comma
