### PR TITLE
Adds logout & logout.post events

### DIFF
--- a/src/ZfcUser/Controller/UserController.php
+++ b/src/ZfcUser/Controller/UserController.php
@@ -111,9 +111,7 @@ class UserController extends AbstractActionController
      */
     public function logoutAction()
     {
-        $this->zfcUserAuthentication()->getAuthAdapter()->resetAdapters();
-        $this->zfcUserAuthentication()->getAuthAdapter()->logoutAdapters();
-        $this->zfcUserAuthentication()->getAuthService()->clearIdentity();
+        $this->getUserService()->logout();
 
         $redirect = $this->params()->fromPost('redirect', $this->params()->fromQuery('redirect', false));
 

--- a/src/ZfcUser/Service/User.php
+++ b/src/ZfcUser/Service/User.php
@@ -152,6 +152,30 @@ class User extends EventProvider implements ServiceManagerAwareInterface
     }
 
     /**
+     * Performs the logout action and triggers a logout event.
+     * @return bool
+     */
+    public function logout()
+    {
+        // NEED TO RETRIEVE THE ADAPTER SINCE IT'S NOT ALREADY BEING USED
+        /** @todo Create a singleton for the adapter? */
+        $adapter = $this->getServiceManager()->get('ZfcUser\Authentication\Adapter\AdapterChain');
+
+        $currentUser = $this->getAuthService()->getIdentity();
+
+        $this->getEventManager()->trigger(__FUNCTION__, $this, array('user' => $currentUser));
+
+        // PERFORM THE LOGOUT ACTIONS
+        $adapter->resetAdapters();
+        $adapter->logoutAdapters();
+        $this->getAuthService()->clearIdentity();
+
+        $this->getEventManager()->trigger(__FUNCTION__, $this, array('user' => $currentUser));
+
+        return true;
+    }
+
+    /**
      * getUserMapper
      *
      * @return UserMapperInterface


### PR DESCRIPTION
Moves the actual logout actions to the User service to be able to trigger pre & post logout events. This makes it simpler to implements features like "remember me".

Usage:

```
// ABOUT TO BE LOGGED OUT
$sharedEventManager->attach(
            'ZfcUser\Service\User',
            'logout',
            function (\Zend\EventManager\Event $e) {
                $user = $e->getParam('user');
            }
        );
```

```
// HAS ALREADY BEEN LOGGED OUT
$sharedEventManager->attach(
            'ZfcUser\Service\User',
            'logout.post',
            function (\Zend\EventManager\Event $e) {
                $user = $e->getParam('user');
            }
        );
```
