### PR TITLE
User controller login action : searching 'redirect' param in POST data too

### DIFF
--- a/src/ZfcUser/Controller/UserController.php
+++ b/src/ZfcUser/Controller/UserController.php
@@ -78,8 +78,8 @@ class UserController extends AbstractActionController
         $request = $this->getRequest();
         $form    = $this->getLoginForm();
 
-        if ($this->getOptions()->getUseRedirectParameterIfPresent() && $request->getQuery()->get('redirect')) {
-            $redirect = $request->getQuery()->get('redirect');
+        if ($this->getOptions()->getUseRedirectParameterIfPresent()) {
+            $redirect = $request->getQuery()->get('redirect', $request->getPost()->get('redirect', false));
         } else {
             $redirect = false;
         }


### PR DESCRIPTION
Hi!
The 'redirect' param should be searched in POST data too. 
Follow this :
- Open login page URL with a 'redirect' GET param.
- An hidden field is created with the value of the 'redirect' param, ok.
- Submit invalid form data (without password for example).
- The 'redirect' GET param disappear because the form METHOD in "login.phtml" view script is `$this->url('zfcuser/login')` (without GET param).
- Yes, the hidden field is well POSTed but not checked by the user controller login action, so the 'redirect' param is lost forever!
  Regards.
