### PR TITLE
Changed `formInput` to `formElement` to enable items like Select etc.!

### DIFF
--- a/view/zfc-user/user/register.phtml
+++ b/view/zfc-user/user/register.phtml
@@ -22,7 +22,7 @@ $form->setAttribute('method', 'post');
         <?php elseif ($element instanceof Zend\Form\Element\Captcha): ?>
             <dd><?php echo $this->formCaptcha($element) . $this->formElementErrors($element) ?></dd>
         <?php else: ?>
-            <dd><?php echo $this->formInput($element) . $this->formElementErrors($element) ?></dd>
+            <dd><?php echo $this->formElement($element) . $this->formElementErrors($element) ?></dd>
         <?php endif ?>
     <?php endforeach ?>
     </dl>


### PR DESCRIPTION
I tried to modify form object to enable to Users to enter country using Select box!

But, it rendered as `<input type='select'>`!

So, to render 'Select' correctly, I changed `formInput` to `formElement`.
