### PR TITLE
Set identity label in both needed spots

### DIFF
--- a/src/ZfcUser/Form/Login.php
+++ b/src/ZfcUser/Form/Login.php
@@ -36,8 +36,8 @@ class Login extends ProvidesEventsForm
         foreach ($this->getAuthenticationOptions()->getAuthIdentityFields() as $mode) {
             $label = (!empty($label) ? $label . ' or ' : '') . ucfirst($mode);
         }
-        $emailElement->setLabel($label);
-        //
+        $emailElement->setOptions(array('label' => $label));
+        
         $this->add(array(
             'name' => 'credential',
             'options' => array(


### PR DESCRIPTION
This will set the identity label in both the label attribute, and the label key in the element's options attribute. We are doing that for credential and some packages (zf2-twb-bundle for example) look for the label in the options array instead of the attribute. Best to belt-and-suspenders and have it in both places.
