### PR TITLE
Use correct element types for form elements

### DIFF
--- a/src/ZfcUser/Form/Base.php
+++ b/src/ZfcUser/Form/Base.php
@@ -23,12 +23,10 @@ class Base extends ProvidesEventsForm
         ));
 
         $this->add(array(
+            'type' => 'email',
             'name' => 'email',
             'options' => array(
                 'label' => 'Email',
-            ),
-            'attributes' => array(
-                'type' => 'text'
             ),
         ));
 
@@ -43,22 +41,18 @@ class Base extends ProvidesEventsForm
         ));
 
         $this->add(array(
+            'type' => 'password',
             'name' => 'password',
             'options' => array(
                 'label' => 'Password',
             ),
-            'attributes' => array(
-                'type' => 'password'
-            ),
         ));
 
         $this->add(array(
+            'type' => 'password',
             'name' => 'passwordVerify',
             'options' => array(
                 'label' => 'Password Verify',
-            ),
-            'attributes' => array(
-                'type' => 'password'
             ),
         ));
 
@@ -73,12 +67,8 @@ class Base extends ProvidesEventsForm
             ));
         }
 
-        $submitElement = new Element\Button('submit');
-        $submitElement
-            ->setLabel('Submit')
-            ->setAttributes(array(
-                'type'  => 'submit',
-            ));
+        $submitElement = new Element\Submit('submit');
+        $submitElement->setLabel('Submit');
 
         $this->add($submitElement, array(
             'priority' => -100,

--- a/src/ZfcUser/Form/ChangeEmail.php
+++ b/src/ZfcUser/Form/ChangeEmail.php
@@ -24,32 +24,34 @@ class ChangeEmail extends ProvidesEventsForm
         ));
 
         $this->add(array(
+            'type' => 'email',
             'name' => 'newIdentity',
             'options' => array(
                 'label' => 'New Email',
             ),
-            'attributes' => array(
-                'type' => 'text',
-            ),
         ));
 
         $this->add(array(
+            'type' => 'email',
             'name' => 'newIdentityVerify',
             'options' => array(
                 'label' => 'Verify New Email',
             ),
-            'attributes' => array(
-                'type' => 'text',
-            ),
         ));
 
         $this->add(array(
+            'type' => 'password',
             'name' => 'credential',
             'options' => array(
                 'label' => 'Password',
             ),
+        ));
+
+        $this->add(array(
+            'type' => 'submit',
+            'name' => 'submit',
             'attributes' => array(
-                'type' => 'password',
+                'value' => 'Submit',
             ),
         ));
 

--- a/src/ZfcUser/Form/ChangePassword.php
+++ b/src/ZfcUser/Form/ChangePassword.php
@@ -31,40 +31,34 @@ class ChangePassword extends ProvidesEventsForm
         ));
 
         $this->add(array(
+            'type' => 'password',
             'name' => 'credential',
             'options' => array(
                 'label' => 'Current Password',
             ),
-            'attributes' => array(
-                'type' => 'password',
-            ),
         ));
 
         $this->add(array(
+            'type' => 'password',
             'name' => 'newCredential',
             'options' => array(
                 'label' => 'New Password',
             ),
-            'attributes' => array(
-                'type' => 'password',
-            ),
         ));
 
         $this->add(array(
+            'type' => 'password',
             'name' => 'newCredentialVerify',
             'options' => array(
                 'label' => 'Verify New Password',
             ),
-            'attributes' => array(
-                'type' => 'password',
-            ),
         ));
 
         $this->add(array(
+            'type' => 'submit',
             'name' => 'submit',
             'attributes' => array(
                 'value' => 'Submit',
-                'type'  => 'submit'
             ),
         ));
 

--- a/src/ZfcUser/Form/Login.php
+++ b/src/ZfcUser/Form/Login.php
@@ -39,12 +39,10 @@ class Login extends ProvidesEventsForm
         $emailElement->setLabel($label);
         //
         $this->add(array(
+            'type' => 'password',
             'name' => 'credential',
             'options' => array(
                 'label' => 'Password',
-            ),
-            'attributes' => array(
-                'type' => 'password',
             ),
         ));
 
@@ -57,12 +55,8 @@ class Login extends ProvidesEventsForm
         //$csrf->getValidator()->setTimeout($options->getLoginFormTimeout());
         //$this->add($csrf);
 
-        $submitElement = new Element\Button('submit');
-        $submitElement
-            ->setLabel('Sign In')
-            ->setAttributes(array(
-                'type'  => 'submit',
-            ));
+        $submitElement = new Element\Submit('submit');
+        $submitElement->setLabel('Sign In');
 
         $this->add($submitElement, array(
             'priority' => -100,

--- a/view/zfc-user/user/changeemail.phtml
+++ b/view/zfc-user/user/changeemail.phtml
@@ -31,5 +31,5 @@ $form->setAttribute('method', 'post');
     <?php if ($this->redirect): ?>
         <input type="hidden" name="redirect" value="<?php echo $this->redirect ?>" />
     <?php endif ?>
-    <input type="submit" value="Submit" />
+    <?php echo $this->formInput($form->get('submit')); ?>
 <?php echo $this->form()->closeTag() ?>


### PR DESCRIPTION
Use correct element types for form elements,
Added submit button to ChangeEmail form

Email fields should be of type email, passwords of type password and submits of type submit.

The ChangeEmail form was missing a submit button. It was only available in the template, which made it impossible to use the form with a generic form-generating partial.
