### PR TITLE
If the travis worker stack is to long we need a bigger timeout (5 minute...

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -4,4 +4,5 @@ imports:
 tools:
     php_cpd: true
     php_pdepend: true
-    external_code_coverage: true
+    external_code_coverage:
+        timeout: 1200


### PR DESCRIPTION
...s is default)
