### PR TITLE
Fix: Ignore composer.lock and vendor directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+composer.lock
+vendor/


### PR DESCRIPTION
Adding 
- `composer.lock` 
- `vendor` 

to the global `.gitignore` is not an option. Is it?
