### PR TITLE
Fix: Remove unused parameter

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -150,7 +150,7 @@ class Module implements
                     return $form;
                 },
 
-                'zfcuser_user_hydrator' => function ($sm) {
+                'zfcuser_user_hydrator' => function () {
                     $hydrator = new \Zend\Stdlib\Hydrator\ClassMethods();
                     return $hydrator;
                 },


### PR DESCRIPTION
The method parameter `$sm` is never used, so no need to specify it.
