### PR TITLE
Add IBM DB2 SQL schema for user table creation

### DIFF
--- a/data/schema.ibmdb2.sql
+++ b/data/schema.ibmdb2.sql
@@ -6,4 +6,4 @@ CREATE TABLE user
     display_name  VARCHAR(50) DEFAULT NULL,
     password      VARCHAR(128) NOT NULL,
     state         SMALLINT
-);
+)


### PR DESCRIPTION
AUTO_INCREMENT isn't valid for SQL in IBM DB2. We instead use GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1). 
