### PR TITLE
Add enableRegistration option to ZfcUserLoginWidget::__invoke()

### DIFF
--- a/src/ZfcUser/View/Helper/ZfcUserLoginWidget.php
+++ b/src/ZfcUser/View/Helper/ZfcUserLoginWidget.php
@@ -30,11 +30,13 @@ class ZfcUserLoginWidget extends AbstractHelper
         $options += array(
             'render' => true,
             'redirect' => false,
+            'enableRegistration' => false,
         );
 
         $vm = new ViewModel(array(
             'loginForm' => $this->getLoginForm(),
             'redirect'  => $options['redirect'],
+            'enableRegistration'  => $options['enableRegistration'],
         ));
         $vm->setTemplate($this->viewTemplate);
         if ($options['render']) {

--- a/tests/ZfcUserTest/View/Helper/ZfcUserLoginWidgetTest.php
+++ b/tests/ZfcUserTest/View/Helper/ZfcUserLoginWidgetTest.php
@@ -101,6 +101,20 @@ class ZfcUserLoginWidgetTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers ZfcUser\View\Helper\ZfcUserLoginWidget::__invoke
+     */
+    public function testInvokeWithEnableRegistration()
+    {
+        $result = $this->helper->__invoke(array(
+            'render' => false,
+            'enableRegistration' => true,
+        ));
+
+        $this->assertInstanceOf('Zend\View\Model\ViewModel', $result);
+        $this->assertTrue($result->enableRegistration);
+    }
+
+    /**
      * @covers ZfcUser\View\Helper\ZfcUserLoginWidget::setLoginForm
      * @covers ZfcUser\View\Helper\ZfcUserLoginWidget::getLoginForm
      */


### PR DESCRIPTION
Adds `enableRegistration` as an option when embedding the login form on a page. 

Similar to #346, but that PR looks stale and appears to do more than simply add the `enableRegistration` option.
