### PR TITLE
New redirect strategy

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -16,14 +16,17 @@ return array(
         ),
     ),
     'controllers' => array(
-        'invokables' => array(
-            'zfcuser' => 'ZfcUser\Controller\UserController',
+        'factories' => array(
+            'zfcuser' => 'ZfcUser\Factory\Controller\UserControllerFactory',
         ),
     ),
     'service_manager' => array(
         'aliases' => array(
             'zfcuser_zend_db_adapter' => 'Zend\Db\Adapter\Adapter',
         ),
+        'factories' => array(
+            'zfcuser_redirect_callback' => 'ZfcUser\Factory\Controller\RedirectCallbackFactory'
+        )
     ),
     'router' => array(
         'routes' => array(

--- a/src/ZfcUser/Controller/RedirectCallback.php
+++ b/src/ZfcUser/Controller/RedirectCallback.php
@@ -77,7 +77,7 @@ class RedirectCallback
     protected function routeExists($route)
     {
         try {
-            $this->router->assemble([], ['name' => $route]);
+            $this->router->assemble(array(), array('name' => $route));
         } catch (Exception\RuntimeException $e) {
             return false;
         }
@@ -103,14 +103,14 @@ class RedirectCallback
         switch ($currentRoute) {
             case 'zfcuser/login':
                 $route = ($redirect) ?: $this->options->getLoginRedirectRoute();
-                return $this->router->assemble([], ['name' => $route]);
+                return $this->router->assemble(array(), array('name' => $route));
                 break;
             case 'zfcuser/logout':
                 $route = ($redirect) ?: $this->options->getLogoutRedirectRoute();
-                return $this->router->assemble([], ['name' => $route]);
+                return $this->router->assemble(array(), array('name' => $route));
                 break;
             default:
-                return $this->router->assemble([], ['name' => 'zfcuser']);
+                return $this->router->assemble(array(), array('name' => 'zfcuser'));
         }
     }
 }

--- a/src/ZfcUser/Controller/RedirectCallback.php
+++ b/src/ZfcUser/Controller/RedirectCallback.php
@@ -9,7 +9,7 @@ use Zend\Http\PhpEnvironment\Response;
 use ZfcUser\Options\ModuleOptions;
 
 /**
- * Returns a redirect response based on the current routing and parameters
+ * Builds a redirect response based on the current routing and parameters
  */
 class RedirectCallback
 {
@@ -54,7 +54,7 @@ class RedirectCallback
      * First checks GET then POST
      * @return string
      */
-    protected function getRedirectRouteFromRequest()
+    private function getRedirectRouteFromRequest()
     {
         $request  = $this->application->getRequest();
         $redirect = $request->getQuery('redirect');
@@ -74,7 +74,7 @@ class RedirectCallback
      * @param $route
      * @return bool
      */
-    protected function routeExists($route)
+    private function routeExists($route)
     {
         try {
             $this->router->assemble(array(), array('name' => $route));
@@ -92,7 +92,7 @@ class RedirectCallback
      * @param bool $redirect
      * @return mixed
      */
-    protected function getRedirect($currentRoute, $redirect = false)
+    private function getRedirect($currentRoute, $redirect = false)
     {
         $useRedirect = $this->options->getUseRedirectParameterIfPresent();
         $routeExists = ($redirect && $this->routeExists($redirect));

--- a/src/ZfcUser/Controller/RedirectCallback.php
+++ b/src/ZfcUser/Controller/RedirectCallback.php
@@ -27,7 +27,8 @@ class RedirectCallback
     protected $options;
 
     /**
-     * @param RouteMatch $router
+     * @param RouteMatch $routeMatch
+     * @param RouteInterface $router
      * @param Response $response
      * @param Request $request
      * @param ModuleOptions $options
@@ -46,9 +47,7 @@ class RedirectCallback
      */
     public function __invoke()
     {
-        $routeMatch = $this->router->match($this->request);
-
-        $redirect = $this->getRedirect($routeMatch->getMatchedRouteName(), $this->getRedirectRouteFromRequest());
+        $redirect = $this->getRedirect($this->routeMatch->getMatchedRouteName(), $this->getRedirectRouteFromRequest());
 
         $response = $this->response;
         $response->getHeaders()->addHeaderLine('Location', $redirect);

--- a/src/ZfcUser/Controller/RedirectCallback.php
+++ b/src/ZfcUser/Controller/RedirectCallback.php
@@ -11,12 +11,9 @@ use ZfcUser\Options\ModuleOptions;
 
 /**
  * Class RedirectCallback
- * @package ZfcUser\Controller
  */
 class RedirectCallback
 {
-    /** @var RouteMatch */
-    private $routeMatch;
 
     /** @var RouteInterface  */
     private $router;
@@ -34,7 +31,6 @@ class RedirectCallback
      */
     public function __construct(Application $application, RouteInterface $router, ModuleOptions $options)
     {
-        $this->routeMatch = $application->getMvcEvent()->getRouteMatch();
         $this->router = $router;
         $this->application = $application;
         $this->options = $options;
@@ -45,7 +41,8 @@ class RedirectCallback
      */
     public function __invoke()
     {
-        $redirect = $this->getRedirect($this->routeMatch->getMatchedRouteName(), $this->getRedirectRouteFromRequest());
+        $routeMatch = $this->application->getMvcEvent()->getRouteMatch();
+        $redirect = $this->getRedirect($routeMatch->getMatchedRouteName(), $this->getRedirectRouteFromRequest());
 
         $response = $this->application->getResponse();
         $response->getHeaders()->addHeaderLine('Location', $redirect);

--- a/src/ZfcUser/Controller/RedirectCallback.php
+++ b/src/ZfcUser/Controller/RedirectCallback.php
@@ -10,7 +10,7 @@ use Zend\Http\PhpEnvironment\Response;
 use ZfcUser\Options\ModuleOptions;
 
 /**
- * Class RedirectCallback
+ * Returns a redirect response based on the current routing and parameters
  */
 class RedirectCallback
 {

--- a/src/ZfcUser/Controller/RedirectCallback.php
+++ b/src/ZfcUser/Controller/RedirectCallback.php
@@ -6,7 +6,6 @@ use Zend\Mvc\Application;
 use Zend\Mvc\Router\RouteInterface;
 use Zend\Mvc\Router\RouteMatch;
 use Zend\Mvc\Router\Exception;
-use Zend\Http\PhpEnvironment\Request;
 use Zend\Http\PhpEnvironment\Response;
 use ZfcUser\Options\ModuleOptions;
 
@@ -17,22 +16,16 @@ use ZfcUser\Options\ModuleOptions;
 class RedirectCallback
 {
     /** @var RouteMatch */
-    protected $routeMatch;
+    private $routeMatch;
 
     /** @var RouteInterface  */
-    protected $router;
-
-    /** @var Response */
-    protected $response;
-
-    /** @var Request */
-    protected $request;
+    private $router;
 
     /** @var Application */
-    protected $application;
+    private $application;
 
     /** @var ModuleOptions */
-    protected $options;
+    private $options;
 
     /**
      * @param Application $application

--- a/src/ZfcUser/Controller/RedirectCallback.php
+++ b/src/ZfcUser/Controller/RedirectCallback.php
@@ -10,6 +10,10 @@ use Zend\Http\PhpEnvironment\Request;
 use Zend\Http\PhpEnvironment\Response;
 use ZfcUser\Options\ModuleOptions;
 
+/**
+ * Class RedirectCallback
+ * @package ZfcUser\Controller
+ */
 class RedirectCallback
 {
     /** @var RouteMatch */
@@ -24,6 +28,9 @@ class RedirectCallback
     /** @var Request */
     protected $request;
 
+    /** @var Application */
+    protected $application;
+
     /** @var ModuleOptions */
     protected $options;
 
@@ -36,8 +43,7 @@ class RedirectCallback
     {
         $this->routeMatch = $application->getMvcEvent()->getRouteMatch();
         $this->router = $router;
-        $this->request = $application->getRequest();
-        $this->response = $application->getResponse();
+        $this->application = $application;
         $this->options = $options;
     }
 
@@ -48,7 +54,7 @@ class RedirectCallback
     {
         $redirect = $this->getRedirect($this->routeMatch->getMatchedRouteName(), $this->getRedirectRouteFromRequest());
 
-        $response = $this->response;
+        $response = $this->application->getResponse();
         $response->getHeaders()->addHeaderLine('Location', $redirect);
         $response->setStatusCode(302);
         return $response;
@@ -61,7 +67,7 @@ class RedirectCallback
      */
     protected function getRedirectRouteFromRequest()
     {
-        $request  = $this->request;
+        $request  = $this->application->getRequest();
         $redirect = $request->getQuery('redirect');
         if ($redirect && $this->routeExists($redirect)) {
             return $redirect;

--- a/src/ZfcUser/Controller/RedirectCallback.php
+++ b/src/ZfcUser/Controller/RedirectCallback.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace ZfcUser\Controller;
+
+use Zend\Mvc\Controller\Plugin\Redirect;
+use Zend\Mvc\Router\RouteInterface;
+use Zend\Mvc\Router\Exception;
+use Zend\Http\PhpEnvironment\Request;
+use Zend\Http\PhpEnvironment\Response;
+use ZfcUser\Options\ModuleOptions;
+
+class RedirectCallback
+{
+    /** @var RouteInterface */
+    protected $router;
+
+    /** @var Response */
+    protected $response;
+
+    /** @var Request */
+    protected $request;
+
+    /** @var ModuleOptions */
+    protected $options;
+
+    /**
+     * @param RouteInterface $router
+     * @param Response $response
+     * @param Request $request
+     * @param ModuleOptions $options
+     */
+    public function __construct(RouteInterface $router, Response $response, Request $request, ModuleOptions $options)
+    {
+        $this->router = $router;
+        $this->request = $request;
+        $this->response = $response;
+        $this->options = $options;
+    }
+
+    /**
+     * @return Response
+     */
+    public function __invoke()
+    {
+        $routeMatch = $this->router->match($this->request);
+        $response = $this->response;
+        $response->getHeaders()->addHeaderLine('Location', $this->getRedirect($routeMatch->getMatchedRouteName(), $routeMatch->getParam('redirect', false)));
+        $response->setStatusCode(302);
+        return $response;
+    }
+
+    /**
+     * @param $route
+     * @return bool
+     */
+    protected function routeExists($route)
+    {
+        try{
+            $this->router->assemble($route);
+        } catch (Exception\RuntimeException $e) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Returns the url to redirect to based on current route.
+     * If $redirect is set and the option to use redirect is set to true, it will return the $redirect url.
+     *
+     * @param string $currentRoute
+     * @param bool $redirect
+     * @return mixed
+     */
+    protected function getRedirect($currentRoute, $redirect = false)
+    {
+        if (!$this->options->getUseRedirectParameterIfPresent() || ($redirect && !$this->routeExists($redirect))) {
+            $redirect = false;
+        }
+
+        switch ($currentRoute) {
+            case 'zfcuser/login':
+                $route = ($redirect) ?: $this->options->getLoginRedirectRoute();
+                return $this->router->assemble([], ['name' => $route]);
+                break;
+            case 'zfcuser/logout':
+                $route = ($redirect) ?: $this->options->getLogoutRedirectRoute();
+                return $this->router->assemble([], ['name' => $route]);
+                break;
+            default:
+                return $this->router->assemble([], ['name' => 'zfcuser']);
+        }
+    }
+
+}

--- a/src/ZfcUser/Controller/RedirectCallback.php
+++ b/src/ZfcUser/Controller/RedirectCallback.php
@@ -2,6 +2,7 @@
 
 namespace ZfcUser\Controller;
 
+use Zend\Mvc\Application;
 use Zend\Mvc\Router\RouteInterface;
 use Zend\Mvc\Router\RouteMatch;
 use Zend\Mvc\Router\Exception;
@@ -27,18 +28,16 @@ class RedirectCallback
     protected $options;
 
     /**
-     * @param RouteMatch $routeMatch
+     * @param Application $application
      * @param RouteInterface $router
-     * @param Response $response
-     * @param Request $request
      * @param ModuleOptions $options
      */
-    public function __construct(RouteMatch $routeMatch, RouteInterface $router, Response $response, Request $request, ModuleOptions $options)
+    public function __construct(Application $application, RouteInterface $router, ModuleOptions $options)
     {
-        $this->routeMatch = $routeMatch;
+        $this->routeMatch = $application->getMvcEvent()->getRouteMatch();
         $this->router = $router;
-        $this->request = $request;
-        $this->response = $response;
+        $this->request = $application->getRequest();
+        $this->response = $application->getResponse();
         $this->options = $options;
     }
 

--- a/src/ZfcUser/Controller/RedirectCallback.php
+++ b/src/ZfcUser/Controller/RedirectCallback.php
@@ -4,7 +4,6 @@ namespace ZfcUser\Controller;
 
 use Zend\Mvc\Application;
 use Zend\Mvc\Router\RouteInterface;
-use Zend\Mvc\Router\RouteMatch;
 use Zend\Mvc\Router\Exception;
 use Zend\Http\PhpEnvironment\Response;
 use ZfcUser\Options\ModuleOptions;

--- a/src/ZfcUser/Controller/RedirectCallback.php
+++ b/src/ZfcUser/Controller/RedirectCallback.php
@@ -82,7 +82,7 @@ class RedirectCallback
     protected function routeExists($route)
     {
         try {
-            $this->router->assemble($route);
+            $this->router->assemble([], ['name' => $route]);
         } catch (Exception\RuntimeException $e) {
             return false;
         }

--- a/src/ZfcUser/Controller/UserController.php
+++ b/src/ZfcUser/Controller/UserController.php
@@ -160,14 +160,11 @@ class UserController extends AbstractActionController
             );
         }
 
-        if ($this->getOptions()->getUseRedirectParameterIfPresent() && $redirect) {
-            return $this->redirect()->toRoute($redirect);
-        }
-
         $route = $this->getOptions()->getLoginRedirectRoute();
 
         if (is_callable($route)) {
             $route = $route($this->zfcUserAuthentication()->getIdentity());
+            return $this->redirect()->toRoute($route);
         }
 
         $redirect = $this->redirectCallback;

--- a/src/ZfcUser/Controller/UserController.php
+++ b/src/ZfcUser/Controller/UserController.php
@@ -56,10 +56,14 @@ class UserController extends AbstractActionController
     protected $options;
 
     /**
-     * @var Callable $redirectCallback
+     * @var callable $redirectCallback
      */
     protected $redirectCallback;
 
+
+    /**
+     * @param callable $redirectCallback
+     */
     public function __construct($redirectCallback)
     {
         $this->redirectCallback = $redirectCallback;

--- a/src/ZfcUser/Controller/UserController.php
+++ b/src/ZfcUser/Controller/UserController.php
@@ -60,12 +60,14 @@ class UserController extends AbstractActionController
      */
     protected $redirectCallback;
 
-
     /**
      * @param callable $redirectCallback
      */
     public function __construct($redirectCallback)
     {
+        if (!is_callable($redirectCallback)) {
+            throw new \InvalidArgumentException('You must supply a callable redirectCallback');
+        }
         $this->redirectCallback = $redirectCallback;
     }
 
@@ -131,6 +133,7 @@ class UserController extends AbstractActionController
         $this->zfcUserAuthentication()->getAuthService()->clearIdentity();
 
         $redirect = $this->redirectCallback;
+
         return $redirect();
     }
 
@@ -172,6 +175,7 @@ class UserController extends AbstractActionController
         }
 
         $redirect = $this->redirectCallback;
+
         return $redirect();
     }
 

--- a/src/ZfcUser/Controller/UserController.php
+++ b/src/ZfcUser/Controller/UserController.php
@@ -56,6 +56,16 @@ class UserController extends AbstractActionController
     protected $options;
 
     /**
+     * @var Callable $redirectCallback
+     */
+    protected $redirectCallback;
+
+    public function __construct($redirectCallback)
+    {
+        $this->redirectCallback = $redirectCallback;
+    }
+
+    /**
      * User page
      */
     public function indexAction()
@@ -116,13 +126,8 @@ class UserController extends AbstractActionController
         $this->zfcUserAuthentication()->getAuthAdapter()->logoutAdapters();
         $this->zfcUserAuthentication()->getAuthService()->clearIdentity();
 
-        $redirect = $this->params()->fromPost('redirect', $this->params()->fromQuery('redirect', false));
-
-        if ($this->getOptions()->getUseRedirectParameterIfPresent() && $redirect) {
-            return $this->redirect()->toRoute($redirect);
-        }
-
-        return $this->redirect()->toRoute($this->getOptions()->getLogoutRedirectRoute());
+        $redirect = $this->redirectCallback;
+        return $redirect();
     }
 
     /**
@@ -165,7 +170,8 @@ class UserController extends AbstractActionController
             $route = $route($this->zfcUserAuthentication()->getIdentity());
         }
 
-        return $this->redirect()->toRoute($route);
+        $redirect = $this->redirectCallback;
+        return $redirect();
     }
 
     /**

--- a/src/ZfcUser/Factory/Controller/RedirectCallbackFactory.php
+++ b/src/ZfcUser/Factory/Controller/RedirectCallbackFactory.php
@@ -1,9 +1,12 @@
 <?php
 namespace ZfcUser\Factory\Controller;
 
+use Zend\Mvc\Application;
+use Zend\Mvc\Router\RouteInterface;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use ZfcUser\Controller\RedirectCallback;
+use ZfcUser\Options\ModuleOptions;
 
 class RedirectCallbackFactory implements FactoryInterface
 {
@@ -12,8 +15,13 @@ class RedirectCallbackFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
+        /* @var RouteInterface $router */
         $router = $serviceLocator->get('Router');
+
+        /* @var Application $application */
         $application = $serviceLocator->get('Application');
+
+        /* @var ModuleOptions $options */
         $options = $serviceLocator->get('zfcuser_module_options');
 
         return new RedirectCallback($application, $router, $options);

--- a/src/ZfcUser/Factory/Controller/RedirectCallbackFactory.php
+++ b/src/ZfcUser/Factory/Controller/RedirectCallbackFactory.php
@@ -13,14 +13,9 @@ class RedirectCallbackFactory implements FactoryInterface
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
         $router = $serviceLocator->get('Router');
-        $response = $serviceLocator->get('Response');
-        $request = $serviceLocator->get('Request');
+        $application = $serviceLocator->get('Application');
         $options = $serviceLocator->get('zfcuser_module_options');
 
-        /** @var MvcEvent $mvcEvent */
-        $mvcEvent   = $serviceLocator->get('Application')->getMvcEvent();
-        $routeMatch = $mvcEvent->getRouteMatch();
-
-        return new RedirectCallback($routeMatch, $router, $response, $request, $options);
+        return new RedirectCallback($application, $router, $options);
     }
 }

--- a/src/ZfcUser/Factory/Controller/RedirectCallbackFactory.php
+++ b/src/ZfcUser/Factory/Controller/RedirectCallbackFactory.php
@@ -16,6 +16,11 @@ class RedirectCallbackFactory implements FactoryInterface
         $response = $serviceLocator->get('Response');
         $request = $serviceLocator->get('Request');
         $options = $serviceLocator->get('zfcuser_module_options');
-        return new RedirectCallback($router, $response, $request, $options);
+
+        /** @var MvcEvent $mvcEvent */
+        $mvcEvent   = $serviceLocator->get('Application')->getMvcEvent();
+        $routeMatch = $mvcEvent->getRouteMatch();
+
+        return new RedirectCallback($routeMatch, $router, $response, $request, $options);
     }
 }

--- a/src/ZfcUser/Factory/Controller/RedirectCallbackFactory.php
+++ b/src/ZfcUser/Factory/Controller/RedirectCallbackFactory.php
@@ -1,0 +1,21 @@
+<?php
+namespace ZfcUser\Factory\Controller;
+
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use ZfcUser\Controller\RedirectCallback;
+
+class RedirectCallbackFactory implements FactoryInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        $router = $serviceLocator->get('Router');
+        $response = $serviceLocator->get('Response');
+        $request = $serviceLocator->get('Request');
+        $options = $serviceLocator->get('zfcuser_module_options');
+        return new RedirectCallback($router, $response, $request, $options);
+    }
+}

--- a/src/ZfcUser/Factory/Controller/UserControllerFactory.php
+++ b/src/ZfcUser/Factory/Controller/UserControllerFactory.php
@@ -5,6 +5,7 @@ use Zend\Mvc\Controller\ControllerManager;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use ZfcUser\Authentication\Adapter;
+use ZfcUser\Controller\RedirectCallback;
 use ZfcUser\Controller\UserController;
 
 class UserControllerFactory implements FactoryInterface
@@ -14,10 +15,13 @@ class UserControllerFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $controllerManager)
     {
-        /** @var ControllerManager $controllerManager*/
+        /* @var ControllerManager $controllerManager*/
         $serviceManager = $controllerManager->getServiceLocator();
 
+        /* @var RedirectCallback $redirectCallback */
         $redirectCallback = $serviceManager->get('zfcuser_redirect_callback');
+
+        /* @var UserController $controller */
         $controller = new UserController($redirectCallback);
 
         return $controller;

--- a/src/ZfcUser/Factory/Controller/UserControllerFactory.php
+++ b/src/ZfcUser/Factory/Controller/UserControllerFactory.php
@@ -1,0 +1,25 @@
+<?php
+namespace ZfcUser\Factory\Controller;
+
+use Zend\Mvc\Controller\ControllerManager;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use ZfcUser\Authentication\Adapter;
+use ZfcUser\Controller\UserController;
+
+class UserControllerFactory implements FactoryInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function createService(ServiceLocatorInterface $controllerManager)
+    {
+        /** @var ControllerManager $controllerManager*/
+        $serviceManager = $controllerManager->getServiceLocator();
+
+        $redirectCallback = $serviceManager->get('zfcuser_redirect_callback');
+        $controller = new UserController($redirectCallback);
+
+        return $controller;
+    }
+}

--- a/tests/ZfcUserTest/Controller/RedirectCallbackTest.php
+++ b/tests/ZfcUserTest/Controller/RedirectCallbackTest.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace ZfcUserTest\Controller;
+
+class RedirectCallbackTest extends \PHPUnit_Framework_TestCase
+{
+
+}

--- a/tests/ZfcUserTest/Controller/RedirectCallbackTest.php
+++ b/tests/ZfcUserTest/Controller/RedirectCallbackTest.php
@@ -2,7 +2,14 @@
 
 namespace ZfcUserTest\Controller;
 
+use Zend\Http\PhpEnvironment\Request;
+use Zend\Http\PhpEnvironment\Response;
+use Zend\Mvc\Application;
+use Zend\Mvc\MvcEvent;
+use Zend\Mvc\Router\RouteInterface;
+use Zend\Mvc\Router\RouteMatch;
 use ZfcUser\Controller\RedirectCallback;
+use ZfcUser\Options\ModuleOptions;
 
 class RedirectCallbackTest extends \PHPUnit_Framework_TestCase
 {
@@ -10,25 +17,25 @@ class RedirectCallbackTest extends \PHPUnit_Framework_TestCase
     /** @var RedirectCallback */
     protected $redirectCallback;
 
-    /** @var PHPUnit_Framework_MockObject_MockObject */
+    /** @var \PHPUnit_Framework_MockObject_MockObject|ModuleOptions */
     protected $moduleOptions;
 
-    /** @var  PHPUnit_Framework_MockObject_MockObject */
+    /** @var  \PHPUnit_Framework_MockObject_MockObject|RouteInterface */
     protected $router;
 
-    /** @var  PHPUnit_Framework_MockObject_MockObject */
+    /** @var  \PHPUnit_Framework_MockObject_MockObject|Application */
     protected $application;
 
-    /** @var  PHPUnit_Framework_MockObject_MockObject */
+    /** @var  \PHPUnit_Framework_MockObject_MockObject|Request */
     protected $request;
 
-    /** @var  PHPUnit_Framework_MockObject_MockObject */
+    /** @var  \PHPUnit_Framework_MockObject_MockObject|Response */
     protected $response;
 
-    /** @var  PHPUnit_Framework_MockObject_MockObject */
+    /** @var  \PHPUnit_Framework_MockObject_MockObject|MvcEvent */
     protected $mvcEvent;
 
-    /** @var  PHPUnit_Framework_MockObject_MockObject */
+    /** @var  \PHPUnit_Framework_MockObject_MockObject|RouteMatch */
     protected $routeMatch;
 
     public function setUp()
@@ -297,7 +304,6 @@ class RedirectCallbackTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-
         $this->routeMatch = $this->getMockBuilder('Zend\Mvc\Router\RouteMatch')
             ->disableOriginalConstructor()
             ->getMock();
@@ -313,10 +319,10 @@ class RedirectCallbackTest extends \PHPUnit_Framework_TestCase
         $this->application->expects($this->once())
             ->method('getMvcEvent')
             ->will($this->returnValue($this->mvcEvent));
-        $this->application->expects($this->once())
+        $this->application->expects($this->any())
             ->method('getRequest')
             ->will($this->returnValue($this->request));
-        $this->application->expects($this->once())
+        $this->application->expects($this->any())
             ->method('getResponse')
             ->will($this->returnValue($this->response));
     }

--- a/tests/ZfcUserTest/Controller/RedirectCallbackTest.php
+++ b/tests/ZfcUserTest/Controller/RedirectCallbackTest.php
@@ -75,7 +75,7 @@ class RedirectCallbackTest extends \PHPUnit_Framework_TestCase
 
         $this->router->expects($this->any())
             ->method('assemble')
-            ->with([], ['name' => 'zfcuser'])
+            ->with(array(), array('name' => 'zfcuser'))
             ->will($this->returnValue($url));
 
         $this->response->expects($this->once())
@@ -105,7 +105,7 @@ class RedirectCallbackTest extends \PHPUnit_Framework_TestCase
         if ($get) {
             $this->router->expects($this->any())
                 ->method('assemble')
-                ->with([], ['name' => $get])
+                ->with(array(), array('name' => $get))
                 ->will($getRouteExists);
 
             if ($getRouteExists == $this->returnValue(true)) {
@@ -121,7 +121,7 @@ class RedirectCallbackTest extends \PHPUnit_Framework_TestCase
             if ($post) {
                 $this->router->expects($this->any())
                     ->method('assemble')
-                    ->with([], ['name' => $post])
+                    ->with(array(), array('name' => $post))
                     ->will($postRouteExists);
 
                 if ($postRouteExists == $this->returnValue(true)) {
@@ -160,7 +160,7 @@ class RedirectCallbackTest extends \PHPUnit_Framework_TestCase
 
         $this->router->expects($this->once())
             ->method('assemble')
-            ->with([], ['name' => $route]);
+            ->with(array(), array('name' => $route));
 
         $method = new \ReflectionMethod(
             'ZfcUser\Controller\RedirectCallback',
@@ -178,7 +178,7 @@ class RedirectCallbackTest extends \PHPUnit_Framework_TestCase
 
         $this->router->expects($this->once())
             ->method('assemble')
-            ->with([], ['name' => $route])
+            ->with(array(), array('name' => $route))
             ->will($this->throwException(new \Zend\Mvc\Router\Exception\RuntimeException));
 
         $method = new \ReflectionMethod(
@@ -204,7 +204,7 @@ class RedirectCallbackTest extends \PHPUnit_Framework_TestCase
             ->method('assemble');
         $this->router->expects($this->at(1))
             ->method('assemble')
-            ->with([], ['name' => $optionsReturn])
+            ->with(array(), array('name' => $optionsReturn))
             ->will($this->returnValue($expectedResult));
 
         if ($optionsMethod) {
@@ -247,7 +247,7 @@ class RedirectCallbackTest extends \PHPUnit_Framework_TestCase
 
         $this->router->expects($this->once())
             ->method('assemble')
-            ->with([], ['name' => $route])
+            ->with(array(), array('name' => $route))
             ->will($this->returnValue($expectedResult));
 
         $method = new \ReflectionMethod(
@@ -272,12 +272,12 @@ class RedirectCallbackTest extends \PHPUnit_Framework_TestCase
 
         $this->router->expects($this->at(0))
             ->method('assemble')
-            ->with([], ['name' => $redirect])
+            ->with(array(), array('name' => $redirect))
             ->will($this->throwException(new \Zend\Mvc\Router\Exception\RuntimeException));
 
         $this->router->expects($this->at(1))
             ->method('assemble')
-            ->with([], ['name' => $route])
+            ->with(array(), array('name' => $route))
             ->will($this->returnValue($expectedResult));
 
         $this->moduleOptions->expects($this->once())

--- a/tests/ZfcUserTest/Controller/RedirectCallbackTest.php
+++ b/tests/ZfcUserTest/Controller/RedirectCallbackTest.php
@@ -326,5 +326,4 @@ class RedirectCallbackTest extends \PHPUnit_Framework_TestCase
             ->method('getResponse')
             ->will($this->returnValue($this->response));
     }
-
 }

--- a/tests/ZfcUserTest/Controller/RedirectCallbackTest.php
+++ b/tests/ZfcUserTest/Controller/RedirectCallbackTest.php
@@ -311,12 +311,12 @@ class RedirectCallbackTest extends \PHPUnit_Framework_TestCase
         $this->mvcEvent = $this->getMockBuilder('Zend\Mvc\MvcEvent')
             ->disableOriginalConstructor()
             ->getMock();
-        $this->mvcEvent->expects($this->once())
+        $this->mvcEvent->expects($this->any())
             ->method('getRouteMatch')
             ->will($this->returnValue($this->routeMatch));
 
 
-        $this->application->expects($this->once())
+        $this->application->expects($this->any())
             ->method('getMvcEvent')
             ->will($this->returnValue($this->mvcEvent));
         $this->application->expects($this->any())

--- a/tests/ZfcUserTest/Controller/RedirectCallbackTest.php
+++ b/tests/ZfcUserTest/Controller/RedirectCallbackTest.php
@@ -2,7 +2,323 @@
 
 namespace ZfcUserTest\Controller;
 
+use ZfcUser\Controller\RedirectCallback;
+
 class RedirectCallbackTest extends \PHPUnit_Framework_TestCase
 {
+
+    /** @var RedirectCallback */
+    protected $redirectCallback;
+
+    /** @var PHPUnit_Framework_MockObject_MockObject */
+    protected $moduleOptions;
+
+    /** @var  PHPUnit_Framework_MockObject_MockObject */
+    protected $router;
+
+    /** @var  PHPUnit_Framework_MockObject_MockObject */
+    protected $application;
+
+    /** @var  PHPUnit_Framework_MockObject_MockObject */
+    protected $request;
+
+    /** @var  PHPUnit_Framework_MockObject_MockObject */
+    protected $response;
+
+    /** @var  PHPUnit_Framework_MockObject_MockObject */
+    protected $mvcEvent;
+
+    /** @var  PHPUnit_Framework_MockObject_MockObject */
+    protected $routeMatch;
+
+    public function setUp()
+    {
+        $this->router = $this->getMockBuilder('Zend\Mvc\Router\RouteInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->moduleOptions = $this->getMockBuilder('ZfcUser\Options\ModuleOptions')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->application = $this->getMockBuilder('Zend\Mvc\Application')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->setUpApplication();
+
+        $this->redirectCallback = new RedirectCallback(
+            $this->application,
+            $this->router,
+            $this->moduleOptions
+        );
+    }
+
+    public function testInvoke()
+    {
+        $url = 'someUrl';
+
+        $this->routeMatch->expects($this->once())
+            ->method('getMatchedRouteName')
+            ->will($this->returnValue('someRoute'));
+
+        $headers = $this->getMock('Zend\Http\Headers');
+        $headers->expects($this->once())
+            ->method('addHeaderLine')
+            ->with('Location', $url);
+
+        $this->router->expects($this->any())
+            ->method('assemble')
+            ->with([], ['name' => 'zfcuser'])
+            ->will($this->returnValue($url));
+
+        $this->response->expects($this->once())
+            ->method('getHeaders')
+            ->will($this->returnValue($headers));
+
+        $this->response->expects($this->once())
+            ->method('setStatusCode')
+            ->with(302);
+
+        $result = $this->redirectCallback->__invoke();
+
+        $this->assertSame($this->response, $result);
+    }
+
+    /**
+     * @dataProvider providerGetRedirectRouteFromRequest
+     */
+    public function testGetRedirectRouteFromRequest($get, $post, $getRouteExists, $postRouteExists)
+    {
+        $expectedResult = false;
+
+        $this->request->expects($this->once())
+            ->method('getQuery')
+            ->will($this->returnValue($get));
+
+        if ($get) {
+            $this->router->expects($this->any())
+                ->method('assemble')
+                ->with([], ['name' => $get])
+                ->will($getRouteExists);
+
+            if ($getRouteExists == $this->returnValue(true)) {
+                $expectedResult = $get;
+            }
+        }
+
+        if (!$get || !$getRouteExists) {
+            $this->request->expects($this->once())
+                ->method('getPost')
+                ->will($this->returnValue($post));
+
+            if ($post) {
+                $this->router->expects($this->any())
+                    ->method('assemble')
+                    ->with([], ['name' => $post])
+                    ->will($postRouteExists);
+
+                if ($postRouteExists == $this->returnValue(true)) {
+                    $expectedResult = $post;
+                }
+            }
+        }
+
+        $method = new \ReflectionMethod(
+            'ZfcUser\Controller\RedirectCallback',
+            'getRedirectRouteFromRequest'
+        );
+        $method->setAccessible(true);
+        $result = $method->invoke($this->redirectCallback);
+
+        $this->assertSame($expectedResult, $result);
+    }
+
+    public function providerGetRedirectRouteFromRequest()
+    {
+        return array(
+            array('user', false, $this->returnValue('route'), false),
+            array('user', false, $this->returnValue('route'), $this->returnValue(true)),
+            array('user', 'user', $this->returnValue('route'), $this->returnValue(true)),
+            array('user', 'user', $this->throwException(new \Zend\Mvc\Router\Exception\RuntimeException), $this->returnValue(true)),
+            array('user', 'user', $this->throwException(new \Zend\Mvc\Router\Exception\RuntimeException), $this->throwException(new \Zend\Mvc\Router\Exception\RuntimeException)),
+            array(false, 'user', false, $this->returnValue(true)),
+            array(false, 'user', false, $this->throwException(new \Zend\Mvc\Router\Exception\RuntimeException)),
+            array(false, 'user', false, $this->throwException(new \Zend\Mvc\Router\Exception\RuntimeException)),
+        );
+    }
+
+    public function testRouteExistsRouteExists()
+    {
+        $route = 'existingRoute';
+
+        $this->router->expects($this->once())
+            ->method('assemble')
+            ->with([], ['name' => $route]);
+
+        $method = new \ReflectionMethod(
+            'ZfcUser\Controller\RedirectCallback',
+            'routeExists'
+        );
+        $method->setAccessible(true);
+        $result = $method->invoke($this->redirectCallback, $route);
+
+        $this->assertTrue($result);
+    }
+
+    public function testRouteExistsRouteDoesntExists()
+    {
+        $route = 'existingRoute';
+
+        $this->router->expects($this->once())
+            ->method('assemble')
+            ->with([], ['name' => $route])
+            ->will($this->throwException(new \Zend\Mvc\Router\Exception\RuntimeException));
+
+        $method = new \ReflectionMethod(
+            'ZfcUser\Controller\RedirectCallback',
+            'routeExists'
+        );
+        $method->setAccessible(true);
+        $result = $method->invoke($this->redirectCallback, $route);
+
+        $this->assertFalse($result);
+    }
+
+    /**
+     * @dataProvider providerGetRedirectNoRedirectParam
+     */
+    public function testGetRedirectNoRedirectParam($currentRoute, $optionsReturn, $expectedResult, $optionsMethod)
+    {
+        $this->moduleOptions->expects($this->once())
+            ->method('getUseRedirectParameterIfPresent')
+            ->will($this->returnValue(true));
+
+        $this->router->expects($this->at(0))
+            ->method('assemble');
+        $this->router->expects($this->at(1))
+            ->method('assemble')
+            ->with([], ['name' => $optionsReturn])
+            ->will($this->returnValue($expectedResult));
+
+        if ($optionsMethod) {
+            $this->moduleOptions->expects($this->never())
+                ->method($optionsMethod)
+                ->will($this->returnValue($optionsReturn));
+        }
+        $method = new \ReflectionMethod(
+            'ZfcUser\Controller\RedirectCallback',
+            'getRedirect'
+        );
+        $method->setAccessible(true);
+        $result = $method->invoke($this->redirectCallback, $currentRoute, $optionsReturn);
+
+        $this->assertSame($expectedResult, $result);
+    }
+
+    public function providerGetRedirectNoRedirectParam()
+    {
+        return array(
+            array('zfcuser/login', 'zfcuser', '/user', 'getLoginRedirectRoute'),
+            array('zfcuser/logout', 'zfcuser/login', '/user/login', 'getLogoutRedirectRoute'),
+            array('testDefault', 'zfcuser', '/home', false),
+        );
+    }
+
+    public function testGetRedirectWithOptionOnButNoRedirect()
+    {
+        $route = 'zfcuser/login';
+        $redirect = false;
+        $expectedResult = '/user/login';
+
+        $this->moduleOptions->expects($this->once())
+            ->method('getUseRedirectParameterIfPresent')
+            ->will($this->returnValue(true));
+
+        $this->moduleOptions->expects($this->once())
+            ->method('getLoginRedirectRoute')
+            ->will($this->returnValue($route));
+
+        $this->router->expects($this->once())
+            ->method('assemble')
+            ->with([], ['name' => $route])
+            ->will($this->returnValue($expectedResult));
+
+        $method = new \ReflectionMethod(
+            'ZfcUser\Controller\RedirectCallback',
+            'getRedirect'
+        );
+        $method->setAccessible(true);
+        $result = $method->invoke($this->redirectCallback, $route, $redirect);
+
+        $this->assertSame($expectedResult, $result);
+    }
+
+    public function testGetRedirectWithOptionOnRedirectDoesntExists()
+    {
+        $route = 'zfcuser/login';
+        $redirect = 'doesntExists';
+        $expectedResult = '/user/login';
+
+        $this->moduleOptions->expects($this->once())
+            ->method('getUseRedirectParameterIfPresent')
+            ->will($this->returnValue(true));
+
+        $this->router->expects($this->at(0))
+            ->method('assemble')
+            ->with([], ['name' => $redirect])
+            ->will($this->throwException(new \Zend\Mvc\Router\Exception\RuntimeException));
+
+        $this->router->expects($this->at(1))
+            ->method('assemble')
+            ->with([], ['name' => $route])
+            ->will($this->returnValue($expectedResult));
+
+        $this->moduleOptions->expects($this->once())
+            ->method('getLoginRedirectRoute')
+            ->will($this->returnValue($route));
+
+        $method = new \ReflectionMethod(
+            'ZfcUser\Controller\RedirectCallback',
+            'getRedirect'
+        );
+        $method->setAccessible(true);
+        $result = $method->invoke($this->redirectCallback, $route, $redirect);
+
+        $this->assertSame($expectedResult, $result);
+    }
+
+    private function setUpApplication()
+    {
+        $this->request = $this->getMockBuilder('Zend\Http\PhpEnvironment\Request')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->response = $this->getMockBuilder('Zend\Http\PhpEnvironment\Response')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+
+        $this->routeMatch = $this->getMockBuilder('Zend\Mvc\Router\RouteMatch')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->mvcEvent = $this->getMockBuilder('Zend\Mvc\MvcEvent')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->mvcEvent->expects($this->once())
+            ->method('getRouteMatch')
+            ->will($this->returnValue($this->routeMatch));
+
+
+        $this->application->expects($this->once())
+            ->method('getMvcEvent')
+            ->will($this->returnValue($this->mvcEvent));
+        $this->application->expects($this->once())
+            ->method('getRequest')
+            ->will($this->returnValue($this->request));
+        $this->application->expects($this->once())
+            ->method('getResponse')
+            ->will($this->returnValue($this->response));
+    }
 
 }

--- a/tests/ZfcUserTest/Controller/UserControllerTest.php
+++ b/tests/ZfcUserTest/Controller/UserControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace ZfcUserTest\Controller;
 
+use ZfcUser\Controller\RedirectCallback;
 use ZfcUser\Controller\UserController as Controller;
 use Zend\Http\Response;
 use Zend\Stdlib\Parameters;
@@ -26,6 +27,9 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
 
     protected $options;
 
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|RedirectCallback
+     */
     protected $redirectCallback;
 
     public function setUp()


### PR DESCRIPTION
I change the way the redirect strategy works.
The redirects from authenticate/logout actions are now callbacks.
This way the user can overwrite the default callback and decide **exactly** what to should happen.

ping @Ocramius

closes #479
closes #476
closes #473
closes #469
