### PR TITLE
Do not require minimum length at login.

### DIFF
--- a/src/ZfcUser/Form/LoginFilter.php
+++ b/src/ZfcUser/Form/LoginFilter.php
@@ -26,14 +26,6 @@ class LoginFilter extends ProvidesEventsInputFilter
         $this->add(array(
             'name'       => 'credential',
             'required'   => true,
-            'validators' => array(
-                array(
-                    'name'    => 'StringLength',
-                    'options' => array(
-                        'min' => 6,
-                    ),
-                ),
-            ),
             'filters'   => array(
                 array('name' => 'StringTrim'),
             ),


### PR DESCRIPTION
I want legacy users to log on to my system using ZfcUser. Among their passwords are ones with a lower number of characters than is configured by default. These are not allowed at the moment.

Of course I can (and have) adapt the input filter to remove this validator. But I guess this validation makes no sense at all. The only downside to non validating would be a performance impact.

So this PR drops it.
