### PR TITLE
Pass user object to preprocess function.

### DIFF
--- a/src/ZfcUser/Authentication/Adapter/Db.php
+++ b/src/ZfcUser/Authentication/Adapter/Db.php
@@ -62,7 +62,6 @@ class Db extends AbstractAdapter implements ServiceManagerAwareInterface
 
         $identity   = $event->getRequest()->getPost()->get('identity');
         $credential = $event->getRequest()->getPost()->get('credential');
-        $credential = $this->preProcessCredential($credential);
         $userObject = null;
 
         // Cycle through the configured identity sources and test each
@@ -95,6 +94,8 @@ class Db extends AbstractAdapter implements ServiceManagerAwareInterface
                 return false;
             }
         }
+
+        $credential = $this->preProcessCredential($credential, $userObject);
 
         $cryptoService = $this->getHydrator()->getCryptoService();
         if (!$cryptoService->verify($credential, $userObject->getPassword())) {
@@ -132,10 +133,10 @@ class Db extends AbstractAdapter implements ServiceManagerAwareInterface
         $this->getMapper()->update($user);
     }
 
-    public function preprocessCredential($credential)
+    public function preprocessCredential($credential, UserEntity $user)
     {
         if (is_callable($this->credentialPreprocessor)) {
-            return call_user_func($this->credentialPreprocessor, $credential);
+            return call_user_func($this->credentialPreprocessor, $credential, $user);
         }
         return $credential;
     }

--- a/tests/ZfcUserTest/Authentication/Adapter/DbTest.php
+++ b/tests/ZfcUserTest/Authentication/Adapter/DbTest.php
@@ -425,7 +425,24 @@ class DbTest extends TestCase
         $this->db->setCredentialPreprocessor(function ($credential) use ($expected) {
             return $expected;
         });
-        $this->assertSame($expected, $this->db->preprocessCredential('ZfcUser'));
+        $this->assertSame($expected, $this->db->preprocessCredential('ZfcUser', $this->user));
+    }
+
+    /**
+     * @covers ZfcUser\Authentication\Adapter\Db::preprocessCredential
+     * @covers ZfcUser\Authentication\Adapter\Db::setCredentialPreprocessor
+     */
+    public function testPreprocessCredentialWithCallableAndAdditionalUserParam()
+    {
+        $expected = 3;
+        $this->user->expects($this->once())
+            ->method('getId')
+            ->will($this->returnValue($expected));
+
+        $this->db->setCredentialPreprocessor(function ($credential, $user) {
+            return $user->getId();
+        });
+        $this->assertSame($expected, $this->db->preprocessCredential('ZfcUser', $this->user));
     }
 
     /**
@@ -433,7 +450,7 @@ class DbTest extends TestCase
      */
     public function testPreprocessCredentialWithoutCallable()
     {
-        $this->assertSame('zfcUser', $this->db->preprocessCredential('zfcUser'));
+        $this->assertSame('zfcUser', $this->db->preprocessCredential('zfcUser', $this->user));
     }
 
     /**


### PR DESCRIPTION
Currently I am trying to let users logon to ZfcUser using legacy passwords. I was thinking of doing so by using the preprocess function. However it fails in that regard.

For this to work I need to have a case distinction between old and new users. I obviously have that state in my `UserEntity` model. There is however no way to access the user object at preprocessing time.

Therefore this PR adds a second paramter to the function passing in the user object. I find the API to still be easy usable and this change is BC because passing in a callback using a single parameter is still valid.
