### PR TITLE
Fix: Avoid FQCN and useless aliasing

### DIFF
--- a/src/ZfcUser/View/Helper/ZfcUserDisplayName.php
+++ b/src/ZfcUser/View/Helper/ZfcUserDisplayName.php
@@ -20,7 +20,7 @@ class ZfcUserDisplayName extends AbstractHelper
      * @access public
      * @param UserInterface $user
      * @throws Exception\DomainException
-     * @return String
+     * @return string
      */
     public function __invoke(UserInterface $user = null)
     {


### PR DESCRIPTION
No need to 
- [x] use FQCN when you can import
- [x] alias what doesn't need to be aliased
