### PR TITLE
Fix: Simplify return annotation

### DIFF
--- a/src/ZfcUser/View/Helper/ZfcUserDisplayName.php
+++ b/src/ZfcUser/View/Helper/ZfcUserDisplayName.php
@@ -64,7 +64,7 @@ class ZfcUserDisplayName extends AbstractHelper
      * Set authService.
      *
      * @param AuthenticationService $authService
-     * @return \ZfcUser\View\Helper\ZfcUserDisplayName
+     * @return self
      */
     public function setAuthService(AuthenticationService $authService)
     {


### PR DESCRIPTION
No need to use a FQCN when returning `$this`.
