### PR TITLE
Fix: No need to wrap, especially not with 1 space indent

### DIFF
--- a/src/ZfcUser/Options/UserServiceOptionsInterface.php
+++ b/src/ZfcUser/Options/UserServiceOptionsInterface.php
@@ -4,7 +4,7 @@ namespace ZfcUser\Options;
 
 use ZfcUser\Options\RegistrationOptionsInterface;
 
-interface UserServiceOptionsInterface extends RegistrationOptionsInterface, AuthenticationOptionsInterface
+interface UserServiceOptionsInterface extends AuthenticationOptionsInterface, RegistrationOptionsInterface
 {
     /**
      * set user entity class name


### PR DESCRIPTION
Also, I find it quite useful to sort interfaces alphabetically - quite helpful when implementing a bunch of interfaces.
