### PR TITLE
Fix: Field is undefined

### DIFF
--- a/src/ZfcUser/Authentication/Adapter/AdapterChainEvent.php
+++ b/src/ZfcUser/Authentication/Adapter/AdapterChainEvent.php
@@ -8,6 +8,11 @@ use Zend\Stdlib\RequestInterface as Request;
 class AdapterChainEvent extends Event
 {
     /**
+     * @var Request
+     */
+    private $request;
+
+    /**
      * getIdentity
      *
      * @return mixed

--- a/src/ZfcUser/Form/ChangeEmail.php
+++ b/src/ZfcUser/Form/ChangeEmail.php
@@ -8,6 +8,11 @@ use ZfcUser\Options\AuthenticationOptionsInterface;
 
 class ChangeEmail extends ProvidesEventsForm
 {
+    /**
+     * @var AuthenticationOptionsInterface
+     */
+    private $authOptions;
+
     public function __construct($name, AuthenticationOptionsInterface $options)
     {
         $this->setAuthenticationOptions($options);


### PR DESCRIPTION
Properties are used, but never defined:
- [x] `$authOptions`
- [x] `$request`
