### PR TITLE
Changing the getRedirect function to protected as I need to extend the c...

### DIFF
--- a/src/ZfcUser/Controller/RedirectCallback.php
+++ b/src/ZfcUser/Controller/RedirectCallback.php
@@ -92,7 +92,7 @@ class RedirectCallback
      * @param bool $redirect
      * @return mixed
      */
-    private function getRedirect($currentRoute, $redirect = false)
+    protected function getRedirect($currentRoute, $redirect = false)
     {
         $useRedirect = $this->options->getUseRedirectParameterIfPresent();
         $routeExists = ($redirect && $this->routeExists($redirect));


### PR DESCRIPTION
...lass at this point.

Use Case: I have a guest login system which uses a separate route to login (zfcuser/guest) and the redirect plug-in is looking explicitly for zfcuser/login to do a redirect. I want to extend the RedirectCallback class with my own which does a check for the login/guest route, set the $currentRoute variable to zfcuser/login then call the parent function. No code duplication. At the moment it requires the entire class to be coppied/pasted to achieve the same functionality.
