### PR TITLE
Fix redirect after register

### DIFF
--- a/src/ZfcUser/Controller/RedirectCallback.php
+++ b/src/ZfcUser/Controller/RedirectCallback.php
@@ -101,7 +101,7 @@ class RedirectCallback
         }
 
         switch ($currentRoute) {
-        	case 'zfcuser/register':
+            case 'zfcuser/register':
             case 'zfcuser/login':
                 $route = ($redirect) ?: $this->options->getLoginRedirectRoute();
                 return $this->router->assemble(array(), array('name' => $route));


### PR DESCRIPTION
https://github.com/ZF-Commons/ZfcUser/issues/520

If the option "login_after_registration" is set to "true", the redirection after the registration is invalid. Because in "getRedirect" function in "RedirectCallback" file, the "zfcuser/register" case is not defined.
