### PR TITLE
Make error message in controller translatable.

### DIFF
--- a/src/ZfcUser/Controller/UserController.php
+++ b/src/ZfcUser/Controller/UserController.php
@@ -477,7 +477,7 @@ class UserController extends AbstractActionController
     public function getTranslator()
     {
         if (!$this->translator && $this->getServiceLocator()) {
-            $this->setTranslator($this->getServiceLocator()->get('translator'));
+            $this->setTranslator($this->getServiceLocator()->get('MvcTranslator'));
         }
 
         return $this->translator;


### PR DESCRIPTION
At the moment the error message that is placed in the controller seems not to be translated. 

The message is copied from the flash messenger into to the form messages. However the FormError renderer that is used by default does not translate messages. Hence no translation.

This PR fixes this by adding the `Translator` as an optional dependency of the `UserController`. If present it is used to translate.
