### PR TITLE
Move login-namespace from flashMessenger to a property

### DIFF
--- a/src/ZfcUser/Controller/UserController.php
+++ b/src/ZfcUser/Controller/UserController.php
@@ -55,6 +55,11 @@ class UserController extends AbstractActionController
     protected $failedLoginMessage = 'Authentication failed. Please try again.';
 
     /**
+     * @var string
+     */
+    protected $loginNamespace = 'zfcuser-login-form';
+
+    /**
      * @var UserControllerOptionsInterface
      */
     protected $options;
@@ -91,7 +96,7 @@ class UserController extends AbstractActionController
         $post    = $request->getPost();
 
         $form    = $this->loginForm;
-        $fm = $this->flashMessenger()->setNamespace('zfcuser-login-form')->getMessages();
+        $fm = $this->flashMessenger()->setNamespace($this->loginNamespace)->getMessages();
         if (isset($fm[0])) {
             $this->loginForm->setMessages(
                 array('identity' => array($fm[0]))
@@ -115,7 +120,7 @@ class UserController extends AbstractActionController
         $form->setData($post);
 
         if (!$form->isValid()) {
-            $this->flashMessenger()->setNamespace('zfcuser-login-form')->addMessage($this->failedLoginMessage);
+            $this->flashMessenger()->setNamespace($this->loginNamespace)->addMessage($this->failedLoginMessage);
             return $this->redirect()->toUrl($this->url()->fromRoute(static::ROUTE_LOGIN).($redirect ? '?redirect='. rawurlencode($redirect) : ''));
         }
 
@@ -166,7 +171,7 @@ class UserController extends AbstractActionController
         $auth = $this->zfcUserAuthentication()->getAuthService()->authenticate($adapter);
 
         if (!$auth->isValid()) {
-            $this->flashMessenger()->setNamespace('zfcuser-login-form')->addMessage($this->failedLoginMessage);
+            $this->flashMessenger()->setNamespace($this->loginNamespace)->addMessage($this->failedLoginMessage);
             $adapter->resetAdapters();
             return $this->redirect()->toUrl(
                 $this->url()->fromRoute(static::ROUTE_LOGIN) .


### PR DESCRIPTION
I want to override the flashmessenger namespace. With this extension I kann extend the UserController and override this property. So I can display my error-message where I want.
