### PR TITLE
Security problem fixed: possibility to insert HTML by URL as redirect pa...

### DIFF
--- a/view/zfc-user/user/login.phtml
+++ b/view/zfc-user/user/login.phtml
@@ -28,5 +28,5 @@ $form->setAttribute('method', 'post');
 <?php echo $this->form()->closeTag() ?>
 
 <?php if ($this->enableRegistration) : ?>
-<?php echo $this->translate('Not registered?'); ?> <a href="<?php echo $this->url('zfcuser/register') . ($this->redirect ? '?redirect='.$this->redirect : '') ?>"><?php echo $this->translate('Sign up!'); ?></a>
+<?php echo $this->translate('Not registered?'); ?> <a href="<?php echo $this->url('zfcuser/register') . ($this->redirect ? '?redirect='.$this->escapeUrl($this->redirect) : '') ?>"><?php echo $this->translate('Sign up!'); ?></a>
 <?php endif; ?>


### PR DESCRIPTION
Security problem fixed: possibility to insert HTML by URL as redirect parameter in login page (XSS).
If you open "/user/login?redirect=%22%3E%3Ca%20href=%22http://github.com%22%3EGitHub.com%3C/a%3E%3Cinpu%20type=%22hidden%22%20%22" you will see appended github link between "Not registered?" and "Sign up!"