### PR TITLE
Fix password Element type (1.x)

### DIFF
--- a/src/ZfcUser/Form/Base.php
+++ b/src/ZfcUser/Form/Base.php
@@ -44,6 +44,7 @@ class Base extends ProvidesEventsForm
 
         $this->add(array(
             'name' => 'password',
+            'type' => 'password',
             'options' => array(
                 'label' => 'Password',
             ),
@@ -54,6 +55,7 @@ class Base extends ProvidesEventsForm
 
         $this->add(array(
             'name' => 'passwordVerify',
+            'type' => 'password',
             'options' => array(
                 'label' => 'Password Verify',
             ),

--- a/src/ZfcUser/Form/ChangeEmail.php
+++ b/src/ZfcUser/Form/ChangeEmail.php
@@ -45,6 +45,7 @@ class ChangeEmail extends ProvidesEventsForm
 
         $this->add(array(
             'name' => 'credential',
+            'type' => 'password',
             'options' => array(
                 'label' => 'Password',
             ),

--- a/src/ZfcUser/Form/ChangePassword.php
+++ b/src/ZfcUser/Form/ChangePassword.php
@@ -32,6 +32,7 @@ class ChangePassword extends ProvidesEventsForm
 
         $this->add(array(
             'name' => 'credential',
+            'type' => 'password',
             'options' => array(
                 'label' => 'Current Password',
             ),
@@ -52,6 +53,7 @@ class ChangePassword extends ProvidesEventsForm
 
         $this->add(array(
             'name' => 'newCredentialVerify',
+            'type' => 'password',
             'options' => array(
                 'label' => 'Verify New Password',
             ),

--- a/src/ZfcUser/Form/Login.php
+++ b/src/ZfcUser/Form/Login.php
@@ -40,6 +40,7 @@ class Login extends ProvidesEventsForm
         //
         $this->add(array(
             'name' => 'credential',
+            'type' => 'password',
             'options' => array(
                 'label' => 'Password',
             ),


### PR DESCRIPTION
ZF2 password elements are built with extra layers of intelligence.  For example, an edit form will not (by default) send the password from a database object back to the browser.

[ZF2 issue #2602](https://github.com/zendframework/zf2/issues/2602) notes that a Password element is not automatically created when the password attribute is sent.  Rather the `type => password` needs to be included in the parent array.  This causes ZfcUser forms (and inheritors) to miss out on these features.

This patch fixes this issue for the 1.x branch.  I have no idea what side-effects this may have as some users may depend on the Element's incorrect behaviors, but it strikes me as an appropriate BC risk since it should enhance intrinsic security of anything that uses ZfcUser.