### PR TITLE
Fix password Element type (2.x)

### DIFF
--- a/src/ZfcUser/Form/Base.php
+++ b/src/ZfcUser/Form/Base.php
@@ -48,7 +48,7 @@ class Base extends ProvidesEventsForm
                 'label' => 'Password',
             ),
             'attributes' => array(
-                'type' => 'password',
+                'type' => 'password'
             ),
         ));
 
@@ -59,7 +59,7 @@ class Base extends ProvidesEventsForm
                 'label' => 'Password Verify',
             ),
             'attributes' => array(
-                'type' => 'password',
+                'type' => 'password'
             ),
         ));
 

--- a/src/ZfcUser/Form/Base.php
+++ b/src/ZfcUser/Form/Base.php
@@ -43,21 +43,17 @@ class Base extends ProvidesEventsForm
 
         $this->add(array(
             'name' => 'password',
+            'type' => 'password',
             'options' => array(
                 'label' => 'Password',
-            ),
-            'attributes' => array(
-                'type' => 'password'
             ),
         ));
 
         $this->add(array(
             'name' => 'passwordVerify',
+            'type' => 'password',
             'options' => array(
                 'label' => 'Password Verify',
-            ),
-            'attributes' => array(
-                'type' => 'password'
             ),
         ));
 

--- a/src/ZfcUser/Form/Base.php
+++ b/src/ZfcUser/Form/Base.php
@@ -47,6 +47,9 @@ class Base extends ProvidesEventsForm
             'options' => array(
                 'label' => 'Password',
             ),
+            'attributes' => array(
+                'type' => 'password',
+            ),
         ));
 
         $this->add(array(
@@ -54,6 +57,9 @@ class Base extends ProvidesEventsForm
             'type' => 'password',
             'options' => array(
                 'label' => 'Password Verify',
+            ),
+            'attributes' => array(
+                'type' => 'password',
             ),
         ));
 

--- a/src/ZfcUser/Form/Login.php
+++ b/src/ZfcUser/Form/Login.php
@@ -38,6 +38,7 @@ class Login extends ProvidesEventsForm
         //
         $this->add(array(
             'name' => 'credential',
+            'type' => 'password',
             'options' => array(
                 'label' => 'Password',
             ),


### PR DESCRIPTION
ZF2 password elements are built with extra layers of intelligence.  For example, an edit form will not (by default) send the password from a database object back to the browser.

[ZF2 issue #2602](https://github.com/zendframework/zf2/issues/2602) notes that a Password element is not automatically created when the password attribute is sent.  Rather the `type => password` needs to be included in the parent array.  This causes ZfcUser forms (and inheritors) to miss out on these features.

This patch fixes this issue for the 2.x branch.  I have no idea what side-effects this may have as some users may depend on the Element's incorrect behaviors, but it strikes me as an appropriate BC risk since it should enhance intrinsic security of anything that uses ZfcUser.