### PR TITLE
IsEmpty check in storage should not trigger reading from the mapper

### DIFF
--- a/src/ZfcUser/Authentication/Storage/Db.php
+++ b/src/ZfcUser/Authentication/Storage/Db.php
@@ -42,7 +42,7 @@ class Db implements Storage\StorageInterface, ServiceManagerAwareInterface
         if ($this->getStorage()->isEmpty()) {
             return true;
         }
-        $identity = $this->read();
+        $identity = $this->getStorage()->read();
         if ($identity === null) {
             $this->clear();
             return true;


### PR DESCRIPTION
```php
$auth = $sm->get('zfcuser_auth_service');

if ($auth->hasIdentity()) {       // Mapper is called here
    $user = $auth->getIdentity(); // instead of here
    // ...
}
```

```php
// Zend\Authentication\AuthenticationService

public function hasIdentity()
{
    return !$this->getStorage()->isEmpty();  // Mapper reads the data inside the isEmpty check
}

public function getIdentity()
{
    $storage = $this->getStorage();

    if ($storage->isEmpty()) {
        return null;
    }

    return $storage->read(); // Here we are using already cached data
}



```



What do you think about this proposal?