### PR TITLE
Fixed spelling of comment in zfcuser.global.php.dist

### DIFF
--- a/config/zfcuser.global.php.dist
+++ b/config/zfcuser.global.php.dist
@@ -158,7 +158,7 @@ $settings = array(
     /**
      * Logout Redirect Route
      *
-     * Upon logging out the user will be redirected to the enterd route
+     * Upon logging out the user will be redirected to the entered route
      *
      * Default value: 'zfcuser/login'
      * Accepted values: A valid route name within your application


### PR DESCRIPTION
Just a typo. Changed "enterd" to "entered"