### PR TITLE
Fixed usage of zfcuser_login_form service in ZfcUserLoginWidget view helper

### DIFF
--- a/src/ZfcUser/Factory/View/Helper/ZfcUserLoginWidget.php
+++ b/src/ZfcUser/Factory/View/Helper/ZfcUserLoginWidget.php
@@ -26,7 +26,7 @@ class ZfcUserLoginWidget implements FactoryInterface
         $locator = $serviceManager->getServiceLocator();
         $viewHelper = new View\Helper\ZfcUserLoginWidget;
         $viewHelper->setViewTemplate($locator->get('zfcuser_module_options')->getUserLoginWidgetViewTemplate());
-        $viewHelper->setLoginForm($locator->get('zfcuser_login_form'));
+        $viewHelper->setLoginForm($locator->get('FormElementManager')->get('zfcuser_login_form'));
         return $viewHelper;
     }
 }


### PR DESCRIPTION
You moved 'zfcuser_login_form' to form_elements. In ZfcUserLoginWidget there was an old reference to the old location. This PR will fix this.