### PR TITLE
Resolves: if login form failure then 'redirect' parameter lost

### DIFF
--- a/src/ZfcUser/Controller/UserController.php
+++ b/src/ZfcUser/Controller/UserController.php
@@ -94,10 +94,10 @@ class UserController extends AbstractActionController
         $request = $this->getRequest();
         $form    = $this->getLoginForm();
 
-        if ($this->getOptions()->getUseRedirectParameterIfPresent() && $request->getQuery()->get('redirect')) {
-            $redirect = $request->getQuery()->get('redirect');
-        } else {
-            $redirect = false;
+        $redirect = false;
+        if ($this->getOptions()->getUseRedirectParameterIfPresent()) {
+            $redirect = $request->isPost() ? $request->getPost()->get('redirect')
+                : $request->getQuery()->get('redirect');
         }
 
         if (!$request->isPost()) {

--- a/tests/ZfcUserTest/Controller/UserControllerTest.php
+++ b/tests/ZfcUserTest/Controller/UserControllerTest.php
@@ -176,7 +176,7 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
             ->method('addMessage')
             ->will($this->returnSelf());
 
-        $postArray = array('some', 'data');
+        $postArray = new Parameters(array('some', 'data'));
         $request = $this->getMock('Zend\Http\Request');
         $request->expects($this->any())
             ->method('isPost')
@@ -264,7 +264,7 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
             $url->expects($this->once())
                 ->method('fromRoute')
                 ->with($controller::ROUTE_LOGIN)
-                ->will($this->returnValue($route_url));
+            ->will($this->returnValue($route_url . $redirectQuery));
 
             $this->pluginManagerPlugins['url']= $url;
             $TEST = true;
@@ -301,8 +301,9 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->pluginManagerPlugins['flashMessenger']= $flashMessenger;
 
+        $isPostTimes = $redirect ? 2 : 1;
         $request = $this->getMock('Zend\Http\Request');
-        $request->expects($this->once())
+        $request->expects($this->exactly($isPostTimes))
             ->method('isPost')
             ->will($this->returnValue(false));
 


### PR DESCRIPTION
On login form failure, 'redirect' parameter is lost.  This change simply propagates the 'redirect' value through the POST.  Tests are working.

https://github.com/ZF-Commons/ZfcUser/issues/629
