### PR TITLE
failedLoginMessage should be translated, too.

### DIFF
--- a/src/ZfcUser/Controller/UserController.php
+++ b/src/ZfcUser/Controller/UserController.php
@@ -117,7 +117,7 @@ class UserController extends AbstractActionController
         $form->setData($request->getPost());
 
         if (!$form->isValid()) {
-            $this->flashMessenger()->setNamespace('zfcuser-login-form')->addMessage($this->failedLoginMessage);
+            $this->flashMessenger()->setNamespace('zfcuser-login-form')->addMessage($this->getServiceLocator()->get('translator')->translate($this->failedLoginMessage));
             return $this->redirect()->toUrl($this->url()->fromRoute(static::ROUTE_LOGIN).($redirect ? '?redirect='. rawurlencode($redirect) : ''));
         }
 

--- a/src/ZfcUser/Controller/UserController.php
+++ b/src/ZfcUser/Controller/UserController.php
@@ -164,7 +164,7 @@ class UserController extends AbstractActionController
         $auth = $this->zfcUserAuthentication()->getAuthService()->authenticate($adapter);
 
         if (!$auth->isValid()) {
-            $this->flashMessenger()->setNamespace('zfcuser-login-form')->addMessage($this->failedLoginMessage);
+            $this->flashMessenger()->setNamespace('zfcuser-login-form')->addMessage($this->getServiceLocator()->get('translator')->translate($this->failedLoginMessage));
             $adapter->resetAdapters();
             return $this->redirect()->toUrl(
                 $this->url()->fromRoute(static::ROUTE_LOGIN) .


### PR DESCRIPTION
If this isn't the intended way of translation, this should be changed nevertheless, as it is of now, the translation is omitted.
