### PR TITLE
ChangePasswordFilter also trigger the `init` event

### DIFF
--- a/src/ZfcUser/Form/ChangePasswordFilter.php
+++ b/src/ZfcUser/Form/ChangePasswordFilter.php
@@ -2,10 +2,10 @@
 
 namespace ZfcUser\Form;
 
-use Zend\InputFilter\InputFilter;
+use ZfcUser\InputFilter\ProvidesEventsInputFilter;
 use ZfcUser\Options\AuthenticationOptionsInterface;
 
-class ChangePasswordFilter extends InputFilter
+class ChangePasswordFilter extends ProvidesEventsInputFilter
 {
     public function __construct(AuthenticationOptionsInterface $options)
     {
@@ -76,5 +76,7 @@ class ChangePasswordFilter extends InputFilter
                 array('name' => 'StringTrim'),
             ),
         ));
+        
+        $this->getEventManager()->trigger('init', $this);
     }
 }


### PR DESCRIPTION
I was trying to add a custom `PasswordStrengthValidator`, and expected an `init` event just like `LoginFilter` and `RegisterFilter`.
This little line would have made it simpler.
Hope it will help.