### PR TITLE
captcha possible for login form

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -2,10 +2,10 @@
 
 namespace ZfcUser;
 
-use Zend\ModuleManager\Feature\ConfigProviderInterface;
-use Zend\ModuleManager\Feature\ControllerPluginProviderInterface;
-use Zend\ModuleManager\Feature\ControllerProviderInterface;
-use Zend\ModuleManager\Feature\ServiceProviderInterface;
+use Laminas\ModuleManager\Feature\ConfigProviderInterface;
+use Laminas\ModuleManager\Feature\ControllerPluginProviderInterface;
+use Laminas\ModuleManager\Feature\ControllerProviderInterface;
+use Laminas\ModuleManager\Feature\ServiceProviderInterface;
 
 class Module implements
     ControllerProviderInterface,
@@ -52,10 +52,10 @@ class Module implements
     {
         return array(
             'aliases' => array(
-                'zfcuser_zend_db_adapter' => \Zend\Db\Adapter\Adapter::class,
+                'zfcuser_zend_db_adapter' => \Laminas\Db\Adapter\Adapter::class,
             ),
             'invokables' => array(
-                'zfcuser_register_form_hydrator' => \Zend\Hydrator\ClassMethods::class,
+                'zfcuser_register_form_hydrator' => \Laminas\Hydrator\ClassMethods::class,
             ),
             'factories' => array(
                 'zfcuser_redirect_callback' => \ZfcUser\Factory\Controller\RedirectCallbackFactory::class,
@@ -63,8 +63,8 @@ class Module implements
                 'ZfcUser\Authentication\Adapter\AdapterChain' => \ZfcUser\Authentication\Adapter\AdapterChainServiceFactory::class,
 
                 // We alias this one because it's ZfcUser's instance of
-                // Zend\Authentication\AuthenticationService. We don't want to
-                // hog the FQCN service alias for a Zend\* class.
+                // Laminas\Authentication\AuthenticationService. We don't want to
+                // hog the FQCN service alias for a Laminas\* class.
                 'zfcuser_auth_service' => \ZfcUser\Factory\AuthenticationService::class,
 
                 'zfcuser_user_hydrator' => \ZfcUser\Factory\UserHydrator::class,

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Created by Evan Coury and the ZF-Commons team
 Introduction
 ------------
 
-ZfcUser is a user registration and authentication module for Zend Framework 2.
-Out of the box, ZfcUser works with Zend\Db, however alternative storage adapter
+ZfcUser is a user registration and authentication module for Laminas Framework 2.
+Out of the box, ZfcUser works with Laminas\Db, however alternative storage adapter
 modules are available (see below). ZfcUser provides the foundations for adding
 user authentication and registration to your ZF2 site. It is designed to be very
 simple and easy to extend.
@@ -22,7 +22,7 @@ Versions
 --------
 Please use below table to figure out what version of ZfcUser you should use.
 
-| ZfcUser version | Supported Zend Framework version | Status                                      |
+| ZfcUser version | Supported Laminas Framework version | Status                                      |
 |-----------------|----------------------------------|---------------------------------------------|
 | 1.x             | <= 2.5                           | Security-fixes only                         |
 | 2.x             | >= 2.6 < 3                       | bug-fixes, security-fixes                   |
@@ -31,7 +31,7 @@ Please use below table to figure out what version of ZfcUser you should use.
 Storage Adapter Modules
 -----------------------
 
-By default, ZfcUser ships with support for using Zend\Db for persisting users.
+By default, ZfcUser ships with support for using Laminas\Db for persisting users.
 However, by installing an optional alternative storage adapter module, you can
 take advantage of other methods of persisting users:
 
@@ -41,7 +41,7 @@ take advantage of other methods of persisting users:
 Requirements
 ------------
 
-* [Zend Framework 2](https://github.com/zendframework/zf2) (latest master)
+* [Laminas Framework](https://github.com/zendframework/zf2) (latest master)
 * [ZfcBase](https://github.com/ZF-Commons/ZfcBase) (latest master).
 
 Features / Goals
@@ -51,7 +51,7 @@ Features / Goals
   username and use strictly email) [COMPLETE]
 * User registration [COMPLETE]
 * Forms protected against CSRF [COMPLETE]
-* Out-of-the-box support for Doctrine2 _and_ Zend\Db [COMPLETE]
+* Out-of-the-box support for Doctrine2 _and_ Laminas\Db [COMPLETE]
 * Robust event system to allow for extending [COMPLETE]
 * Provide ActionController plugin and view helper [COMPLETE]
 
@@ -107,9 +107,9 @@ Coming soon...
 
 Coming soon...
 
-### Post-Install: Zend\Db
+### Post-Install: Laminas\Db
 
-1. If you do not already have a valid Zend\Db\Adapter\Adapter in your service
+1. If you do not already have a valid Laminas\Db\Adapter\Adapter in your service
    manager configuration, put the following in `./config/autoload/database.local.php`:
 
 ```php
@@ -124,7 +124,7 @@ return array(
     ),
     'service_manager' => array(
         'factories' => array(
-            'Zend\Db\Adapter\Adapter' => 'Zend\Db\Adapter\AdapterServiceFactory',
+            'Laminas\Db\Adapter\Adapter' => 'Laminas\Db\Adapter\AdapterServiceFactory',
         ),
     ),
 );
@@ -183,8 +183,8 @@ The following options are available:
   after they successfully register. Default value is `false`.
 - **use_registration_form_captcha** - Boolean value, determines if a captcha should
   be utilized on the user registration form. Default value is `true`. (Note,
-  right now this only utilizes a weak Zend\Text\Figlet CAPTCHA, but I have plans
-  to make all Zend\Captcha adapters work.)
+  right now this only utilizes a weak Laminas\Text\Figlet CAPTCHA, but I have plans
+  to make all Laminas\Captcha adapters work.)
 - **login_form_timeout** - Integer value, specify the timeout for the CSRF security
   field of the login form in seconds. Default value is 300 seconds.
 - **user_form_timeout** - Integer value, specify the timeout for the CSRF security
@@ -226,7 +226,7 @@ module.config.php, or a dedicated recaptcha.config.php):
             'instance'=>array(
                 'alias'=>array(
                     // OTHER ELEMENTS....
-                    'recaptcha_element' => 'Zend\Form\Element\Captcha',
+                    'recaptcha_element' => 'Laminas\Form\Element\Captcha',
                 ),
                 'recaptcha_element' => array(
                     'parameters' => array(

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "zf-commons/zfc-user",
+    "name": "lampi87/zfc-user",
     "description": "A generic user registration and authentication module for ZF2. Supports Zend\\Db and Doctrine2.",
     "type": "library",
     "license": "BSD-3-Clause",
@@ -25,34 +25,34 @@
         }
     },
     "require": {
-        "php": "^5.5|^7.0",
-        "zendframework/zend-authentication": "^2.5",
-        "zendframework/zend-crypt": "^3.0",
-        "zendframework/zend-form": "^2.9",
-        "zendframework/zend-inputfilter": "^2.7",
-        "zendframework/zend-loader": "^2.5",
-        "zendframework/zend-modulemanager": "^2.7",
-        "zendframework/zend-mvc": "^3.0",
-        "zendframework/zend-servicemanager": "^3.0",
-        "zendframework/zend-stdlib": "^3.0",
-        "zendframework/zend-validator": "^2.8",
-        "zendframework/zend-db": "^2.8",
-        "zendframework/zend-view": "^2.8",
-        "zendframework/zend-session" : "^2.7",
-        "zendframework/zend-http" : "^2.5",
-        "zendframework/zend-mvc-plugin-flashmessenger": "^1.0",
-        "zendframework/zend-i18n": "^2.7",
-        "zendframework/zend-mvc-plugin-prg": "^1.0",
-        "zendframework/zend-hydrator": "^2.0"
+        "php": "^7.0",
+        "laminas/laminas-authentication": "^2.5",
+        "laminas/laminas-crypt": "^3.0",
+        "laminas/laminas-form": "^2.9",
+        "laminas/laminas-inputfilter": "^2.7",
+        "laminas/laminas-loader": "^2.5",
+        "laminas/laminas-modulemanager": "^2.7",
+        "laminas/laminas-mvc": "^3.0",
+        "laminas/laminas-servicemanager": "^3.0",
+        "laminas/laminas-stdlib": "^3.0",
+        "laminas/laminas-validator": "^2.8",
+        "laminas/laminas-db": "^2.8",
+        "laminas/laminas-view": "^2.8",
+        "laminas/laminas-session" : "^2.7",
+        "laminas/laminas-http" : "^2.5",
+        "laminas/laminas-mvc-plugin-flashmessenger": "^1.0",
+        "laminas/laminas-i18n": "^2.7",
+        "laminas/laminas-mvc-plugin-prg": "^1.0",
+        "laminas/laminas-hydrator": "^2.0"
     },
     "require-dev" : {
-        "phpunit/phpunit" : ">=3.7,<4",
-        "phpmd/phpmd" : "1.4.*",
-        "squizlabs/php_codesniffer" : "1.4.*",
-        "zendframework/zend-captcha" : "^2.6"
+        "phpunit/phpunit" : "*",
+        "phpmd/phpmd" : "*",
+        "squizlabs/php_codesniffer" : "*",
+        "laminas/laminas-captcha" : "^2.6"
     },
     "suggest": {
-        "zendframework/zend-captcha" : "Zend\\Captcha if you want to use the captcha component"
+        "laminas/laminas-captcha" : "Zend\\Captcha if you want to use the captcha component"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "lampi87/zfc-user",
-    "description": "A generic user registration and authentication module for ZF2. Supports Zend\\Db and Doctrine2.",
+    "description": "A generic user registration and authentication module for ZF2. Supports Laminas\\Db and Doctrine2.",
     "type": "library",
     "license": "BSD-3-Clause",
     "keywords": [
@@ -52,7 +52,7 @@
         "laminas/laminas-captcha" : "^2.6"
     },
     "suggest": {
-        "laminas/laminas-captcha" : "Zend\\Captcha if you want to use the captcha component"
+        "laminas/laminas-captcha" : "Laminas\\Captcha if you want to use the captcha component"
     },
     "autoload": {
         "psr-0": {

--- a/config/zfcuser.global.php.dist
+++ b/config/zfcuser.global.php.dist
@@ -7,12 +7,12 @@
  */
 $settings = array(
     /**
-     * Zend\Db\Adapter\Adapter DI Alias
+     * Laminas\Db\Adapter\Adapter DI Alias
      *
-     * Please specify the DI alias for the configured Zend\Db\Adapter\Adapter
+     * Please specify the DI alias for the configured Laminas\Db\Adapter\Adapter
      * instance that ZfcUser should use.
      */
-    //'zend_db_adapter' => 'Zend\Db\Adapter\Adapter',
+    //'zend_db_adapter' => 'Laminas\Db\Adapter\Adapter',
 
     /**
      * User Model Entity Class
@@ -123,7 +123,7 @@ $settings = array(
      * Form Captcha Options
      *
      * Currently used for the registration form, but re-usable anywhere. Use
-     * this to configure which Zend\Captcha adapter to use, and the options to
+     * this to configure which Laminas\Captcha adapter to use, and the options to
      * pass to it. The default uses the Figlet captcha.
      */
     /*'form_captcha_options' => array(
@@ -237,7 +237,7 @@ return array(
     'zfcuser' => $settings,
     'service_manager' => array(
         'aliases' => array(
-            'zfcuser_zend_db_adapter' => (isset($settings['zend_db_adapter'])) ? $settings['zend_db_adapter']: 'Zend\Db\Adapter\Adapter',
+            'zfcuser_zend_db_adapter' => (isset($settings['zend_db_adapter'])) ? $settings['zend_db_adapter']: 'Laminas\Db\Adapter\Adapter',
         ),
     ),
 );

--- a/config/zfcuser.global.php.dist
+++ b/config/zfcuser.global.php.dist
@@ -112,6 +112,14 @@ $settings = array(
     //'use_registration_form_captcha' => false,
 
     /**
+     * Login Form Captcha
+     *
+     * Determines if a captcha should be utilized on the user login form.
+     * Default value is false.
+     */
+    //'use_login_form_captcha' => false,
+
+    /**
      * Form Captcha Options
      *
      * Currently used for the registration form, but re-usable anywhere. Use

--- a/src/ZfcUser/Authentication/Adapter/AbstractAdapter.php
+++ b/src/ZfcUser/Authentication/Adapter/AbstractAdapter.php
@@ -2,7 +2,7 @@
 
 namespace ZfcUser\Authentication\Adapter;
 
-use Zend\Authentication\Storage;
+use Laminas\Authentication\Storage;
 
 abstract class AbstractAdapter implements ChainableAdapter
 {

--- a/src/ZfcUser/Authentication/Adapter/AbstractAdapter.php
+++ b/src/ZfcUser/Authentication/Adapter/AbstractAdapter.php
@@ -21,7 +21,7 @@ abstract class AbstractAdapter implements ChainableAdapter
     public function getStorage()
     {
         if (null === $this->storage) {
-            $this->setStorage(new Storage\Session(get_class($this)));
+            $this->setStorage(new Storage\Session('ZfcUser'));
         }
 
         return $this->storage;

--- a/src/ZfcUser/Authentication/Adapter/AdapterChain.php
+++ b/src/ZfcUser/Authentication/Adapter/AdapterChain.php
@@ -2,13 +2,13 @@
 
 namespace ZfcUser\Authentication\Adapter;
 
-use Zend\Authentication\Adapter\AdapterInterface;
-use Zend\Authentication\Result as AuthenticationResult;
-use Zend\EventManager\Event;
-use Zend\EventManager\EventInterface;
-use Zend\EventManager\EventManagerAwareTrait;
-use Zend\Stdlib\RequestInterface as Request;
-use Zend\Stdlib\ResponseInterface as Response;
+use Laminas\Authentication\Adapter\AdapterInterface;
+use Laminas\Authentication\Result as AuthenticationResult;
+use Laminas\EventManager\Event;
+use Laminas\EventManager\EventInterface;
+use Laminas\EventManager\EventManagerAwareTrait;
+use Laminas\Stdlib\RequestInterface as Request;
+use Laminas\Stdlib\ResponseInterface as Response;
 use ZfcUser\Exception;
 
 class AdapterChain implements AdapterInterface

--- a/src/ZfcUser/Authentication/Adapter/AdapterChainEvent.php
+++ b/src/ZfcUser/Authentication/Adapter/AdapterChainEvent.php
@@ -2,8 +2,8 @@
 
 namespace ZfcUser\Authentication\Adapter;
 
-use Zend\EventManager\Event;
-use Zend\Stdlib\RequestInterface as Request;
+use Laminas\EventManager\Event;
+use Laminas\Stdlib\RequestInterface as Request;
 
 class AdapterChainEvent extends Event
 {

--- a/src/ZfcUser/Authentication/Adapter/AdapterChainServiceFactory.php
+++ b/src/ZfcUser/Authentication/Adapter/AdapterChainServiceFactory.php
@@ -3,10 +3,10 @@ namespace ZfcUser\Authentication\Adapter;
 
 use Interop\Container\ContainerInterface;
 use Interop\Container\Exception\ContainerException;
-use Zend\ServiceManager\Exception\ServiceNotCreatedException;
-use Zend\ServiceManager\Exception\ServiceNotFoundException;
-use Zend\ServiceManager\Factory\FactoryInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
+use Laminas\ServiceManager\Exception\ServiceNotFoundException;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Laminas\ServiceManager\ServiceLocatorInterface;
 use ZfcUser\Authentication\Adapter\AdapterChain;
 use ZfcUser\Options\ModuleOptions;
 use ZfcUser\Authentication\Adapter\Exception\OptionsNotFoundException;

--- a/src/ZfcUser/Authentication/Adapter/ChainableAdapter.php
+++ b/src/ZfcUser/Authentication/Adapter/ChainableAdapter.php
@@ -2,8 +2,8 @@
 
 namespace ZfcUser\Authentication\Adapter;
 
-use Zend\Authentication\Storage\StorageInterface;
-use Zend\EventManager\EventInterface;
+use Laminas\Authentication\Storage\StorageInterface;
+use Laminas\EventManager\EventInterface;
 
 interface ChainableAdapter
 {

--- a/src/ZfcUser/Authentication/Adapter/Db.php
+++ b/src/ZfcUser/Authentication/Adapter/Db.php
@@ -105,7 +105,7 @@ class Db extends AbstractAdapter
         }
 
         // regen the id
-        $session = new SessionContainer($this->getStorage()->getNameSpace());
+        $session = new SessionContainer('ZfcUser');
         $session->getManager()->regenerateId();
 
         // Success!

--- a/src/ZfcUser/Authentication/Adapter/Db.php
+++ b/src/ZfcUser/Authentication/Adapter/Db.php
@@ -3,11 +3,11 @@
 namespace ZfcUser\Authentication\Adapter;
 
 use Interop\Container\ContainerInterface;
-use Zend\Authentication\Result as AuthenticationResult;
-use Zend\EventManager\EventInterface;
-use Zend\ServiceManager\ServiceManager;
-use Zend\Crypt\Password\Bcrypt;
-use Zend\Session\Container as SessionContainer;
+use Laminas\Authentication\Result as AuthenticationResult;
+use Laminas\EventManager\EventInterface;
+use Laminas\ServiceManager\ServiceManager;
+use Laminas\Crypt\Password\Bcrypt;
+use Laminas\Session\Container as SessionContainer;
 use ZfcUser\Entity\UserInterface;
 use ZfcUser\Mapper\UserInterface as UserMapperInterface;
 use ZfcUser\Options\ModuleOptions;

--- a/src/ZfcUser/Authentication/Adapter/Exception/OptionsNotFoundException.php
+++ b/src/ZfcUser/Authentication/Adapter/Exception/OptionsNotFoundException.php
@@ -2,7 +2,7 @@
 
 namespace ZfcUser\Authentication\Adapter\Exception;
 
-use Zend\Math\Exception\RuntimeException;
+use Laminas\Math\Exception\RuntimeException;
 
 class OptionsNotFoundException extends RuntimeException
 {

--- a/src/ZfcUser/Authentication/Storage/Db.php
+++ b/src/ZfcUser/Authentication/Storage/Db.php
@@ -3,9 +3,9 @@
 namespace ZfcUser\Authentication\Storage;
 
 use Interop\Container\ContainerInterface;
-use Zend\Authentication\Storage;
-use Zend\Authentication\Storage\StorageInterface;
-use Zend\ServiceManager\ServiceManager;
+use Laminas\Authentication\Storage;
+use Laminas\Authentication\Storage\StorageInterface;
+use Laminas\ServiceManager\ServiceManager;
 use ZfcUser\Mapper\UserInterface as UserMapper;
 
 class Db implements Storage\StorageInterface
@@ -33,7 +33,7 @@ class Db implements Storage\StorageInterface
     /**
      * Returns true if and only if storage is empty
      *
-     * @throws \Zend\Authentication\Exception\InvalidArgumentException If it is impossible to determine whether
+     * @throws \Laminas\Authentication\Exception\InvalidArgumentException If it is impossible to determine whether
      * storage is empty or not
      * @return boolean
      */
@@ -56,7 +56,7 @@ class Db implements Storage\StorageInterface
      *
      * Behavior is undefined when storage is empty.
      *
-     * @throws \Zend\Authentication\Exception\InvalidArgumentException If reading contents from storage is impossible
+     * @throws \Laminas\Authentication\Exception\InvalidArgumentException If reading contents from storage is impossible
      * @return mixed
      */
     public function read()
@@ -84,7 +84,7 @@ class Db implements Storage\StorageInterface
      * Writes $contents to storage
      *
      * @param  mixed $contents
-     * @throws \Zend\Authentication\Exception\InvalidArgumentException If writing $contents to storage is impossible
+     * @throws \Laminas\Authentication\Exception\InvalidArgumentException If writing $contents to storage is impossible
      * @return void
      */
     public function write($contents)
@@ -96,7 +96,7 @@ class Db implements Storage\StorageInterface
     /**
      * Clears contents from storage
      *
-     * @throws \Zend\Authentication\Exception\InvalidArgumentException If clearing contents from storage is impossible
+     * @throws \Laminas\Authentication\Exception\InvalidArgumentException If clearing contents from storage is impossible
      * @return void
      */
     public function clear()

--- a/src/ZfcUser/Controller/Plugin/ZfcUserAuthentication.php
+++ b/src/ZfcUser/Controller/Plugin/ZfcUserAuthentication.php
@@ -2,9 +2,9 @@
 
 namespace ZfcUser\Controller\Plugin;
 
-use Zend\Mvc\Controller\Plugin\AbstractPlugin;
-use Zend\Authentication\AuthenticationService;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Laminas\Mvc\Controller\Plugin\AbstractPlugin;
+use Laminas\Authentication\AuthenticationService;
+use Laminas\ServiceManager\ServiceLocatorInterface;
 use ZfcUser\Authentication\Adapter\AdapterChain as AuthAdapter;
 
 class ZfcUserAuthentication extends AbstractPlugin

--- a/src/ZfcUser/Controller/RedirectCallback.php
+++ b/src/ZfcUser/Controller/RedirectCallback.php
@@ -2,10 +2,10 @@
 
 namespace ZfcUser\Controller;
 
-use Zend\Mvc\Application;
-use Zend\Router\RouteInterface;
-use Zend\Router\Exception;
-use Zend\Http\PhpEnvironment\Response;
+use Laminas\Mvc\Application;
+use Laminas\Router\RouteInterface;
+use Laminas\Router\Exception;
+use Laminas\Http\PhpEnvironment\Response;
 use ZfcUser\Options\ModuleOptions;
 
 /**

--- a/src/ZfcUser/Controller/UserController.php
+++ b/src/ZfcUser/Controller/UserController.php
@@ -2,12 +2,12 @@
 
 namespace ZfcUser\Controller;
 
-use Zend\Form\FormInterface;
-use Zend\Mvc\Controller\AbstractActionController;
-use Zend\ServiceManager\ServiceLocatorInterface;
-use Zend\Stdlib\ResponseInterface as Response;
-use Zend\Stdlib\Parameters;
-use Zend\View\Model\ViewModel;
+use Laminas\Form\FormInterface;
+use Laminas\Mvc\Controller\AbstractActionController;
+use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\Stdlib\ResponseInterface as Response;
+use Laminas\Stdlib\Parameters;
+use Laminas\View\Model\ViewModel;
 use ZfcUser\Service\User as UserService;
 use ZfcUser\Options\UserControllerOptionsInterface;
 

--- a/src/ZfcUser/Db/Adapter/MasterSlaveAdapter.php
+++ b/src/ZfcUser/Db/Adapter/MasterSlaveAdapter.php
@@ -1,9 +1,9 @@
 <?php
 namespace ZfcBase\Db\Adapter;
 
-use Zend\Db\Adapter\Adapter;
-use Zend\Db\Adapter\Platform;
-use Zend\Db\ResultSet;
+use Laminas\Db\Adapter\Adapter;
+use Laminas\Db\Adapter\Platform;
+use Laminas\Db\ResultSet;
 
 class MasterSlaveAdapter extends Adapter implements MasterSlaveAdapterInterface
 {

--- a/src/ZfcUser/Db/Adapter/MasterSlaveAdapterInterface.php
+++ b/src/ZfcUser/Db/Adapter/MasterSlaveAdapterInterface.php
@@ -4,7 +4,7 @@ namespace ZfcUser\Db\Adapter;
 interface MasterSlaveAdapterInterface
 {
     /**
-     * @return \Zend\Db\Adapter\Adapter
+     * @return \Laminas\Db\Adapter\Adapter
      */
     public function getSlaveAdapter();
 }

--- a/src/ZfcUser/Entity/UserInterface.php
+++ b/src/ZfcUser/Entity/UserInterface.php
@@ -82,14 +82,14 @@ interface UserInterface
     /**
      * Get state.
      *
-     * @return int
+     * @return boolean
      */
     public function getState();
 
     /**
      * Set state.
      *
-     * @param int $state
+     * @param boolean $state
      * @return UserInterface
      */
     public function setState($state);

--- a/src/ZfcUser/Entity/UserInterface.php
+++ b/src/ZfcUser/Entity/UserInterface.php
@@ -90,7 +90,6 @@ interface UserInterface
      * Set state.
      *
      * @param boolean $state
-     * @return UserInterface
      */
     public function setState($state);
 }

--- a/src/ZfcUser/Entity/UserInterface.php
+++ b/src/ZfcUser/Entity/UserInterface.php
@@ -67,14 +67,14 @@ interface UserInterface
     /**
      * Get password.
      *
-     * @return string password
+     * @return string|null password
      */
     public function getPassword();
 
     /**
      * Set password.
      *
-     * @param string $password
+     * @param string|null $password
      * @return UserInterface
      */
     public function setPassword($password);

--- a/src/ZfcUser/EventManager/EventProvider.php
+++ b/src/ZfcUser/EventManager/EventProvider.php
@@ -2,10 +2,10 @@
 namespace ZfcUser\EventManager;
 
 use Traversable;
-use Zend\EventManager\EventManagerAwareInterface;
-use Zend\EventManager\EventManagerInterface;
-use Zend\EventManager\EventManager;
-use Zend\EventManager\SharedEventManager;
+use Laminas\EventManager\EventManagerAwareInterface;
+use Laminas\EventManager\EventManagerInterface;
+use Laminas\EventManager\EventManager;
+use Laminas\EventManager\SharedEventManager;
 
 abstract class EventProvider implements EventManagerAwareInterface
 {

--- a/src/ZfcUser/Factory/Authentication/Adapter/DbFactory.php
+++ b/src/ZfcUser/Factory/Authentication/Adapter/DbFactory.php
@@ -3,8 +3,8 @@
 namespace ZfcUser\Factory\Authentication\Adapter;
 
 use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\Factory\FactoryInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Laminas\ServiceManager\ServiceLocatorInterface;
 use ZfcUser\Authentication\Adapter\Db;
 
 class DbFactory implements FactoryInterface

--- a/src/ZfcUser/Factory/Authentication/Storage/DbFactory.php
+++ b/src/ZfcUser/Factory/Authentication/Storage/DbFactory.php
@@ -3,8 +3,8 @@
 namespace ZfcUser\Factory\Authentication\Storage;
 
 use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\Factory\FactoryInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Laminas\ServiceManager\ServiceLocatorInterface;
 use ZfcUser\Authentication\Storage\Db;
 
 class DbFactory implements FactoryInterface

--- a/src/ZfcUser/Factory/AuthenticationService.php
+++ b/src/ZfcUser/Factory/AuthenticationService.php
@@ -3,14 +3,14 @@
 namespace ZfcUser\Factory;
 
 use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\Factory\FactoryInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Laminas\ServiceManager\ServiceLocatorInterface;
 
 class AuthenticationService implements FactoryInterface
 {
     public function __invoke(ContainerInterface $serviceLocator, $requestedName, array $options = null)
     {
-        return new \Zend\Authentication\AuthenticationService(
+        return new \Laminas\Authentication\AuthenticationService(
             $serviceLocator->get('ZfcUser\Authentication\Storage\Db'),
             $serviceLocator->get('ZfcUser\Authentication\Adapter\AdapterChain')
         );

--- a/src/ZfcUser/Factory/Controller/Plugin/ZfcUserAuthentication.php
+++ b/src/ZfcUser/Factory/Controller/Plugin/ZfcUserAuthentication.php
@@ -3,8 +3,8 @@
 namespace ZfcUser\Factory\Controller\Plugin;
 
 use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\Factory\FactoryInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Laminas\ServiceManager\ServiceLocatorInterface;
 use ZfcUser\Controller;
 
 class ZfcUserAuthentication implements FactoryInterface

--- a/src/ZfcUser/Factory/Controller/RedirectCallbackFactory.php
+++ b/src/ZfcUser/Factory/Controller/RedirectCallbackFactory.php
@@ -3,10 +3,10 @@
 namespace ZfcUser\Factory\Controller;
 
 use Interop\Container\ContainerInterface;
-use Zend\Mvc\Application;
-use Zend\Router\RouteInterface;
-use Zend\ServiceManager\Factory\FactoryInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Laminas\Mvc\Application;
+use Laminas\Router\RouteInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Laminas\ServiceManager\ServiceLocatorInterface;
 use ZfcUser\Controller\RedirectCallback;
 use ZfcUser\Options\ModuleOptions;
 

--- a/src/ZfcUser/Factory/Controller/UserControllerFactory.php
+++ b/src/ZfcUser/Factory/Controller/UserControllerFactory.php
@@ -3,9 +3,9 @@
 namespace ZfcUser\Factory\Controller;
 
 use Interop\Container\ContainerInterface;
-use Zend\Mvc\Controller\ControllerManager;
-use Zend\ServiceManager\Factory\FactoryInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Laminas\Mvc\Controller\ControllerManager;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Laminas\ServiceManager\ServiceLocatorInterface;
 use ZfcUser\Controller\RedirectCallback;
 use ZfcUser\Controller\UserController;
 

--- a/src/ZfcUser/Factory/Form/ChangeEmail.php
+++ b/src/ZfcUser/Factory/Form/ChangeEmail.php
@@ -3,7 +3,7 @@
 namespace ZfcUser\Factory\Form;
 
 use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\Factory\FactoryInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 use ZfcUser\Form;
 use ZfcUser\Validator;
 

--- a/src/ZfcUser/Factory/Form/ChangePassword.php
+++ b/src/ZfcUser/Factory/Form/ChangePassword.php
@@ -3,7 +3,7 @@
 namespace ZfcUser\Factory\Form;
 
 use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\Factory\FactoryInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 use ZfcUser\Form;
 
 class ChangePassword implements FactoryInterface

--- a/src/ZfcUser/Factory/Form/Login.php
+++ b/src/ZfcUser/Factory/Form/Login.php
@@ -3,7 +3,7 @@
 namespace ZfcUser\Factory\Form;
 
 use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\Factory\FactoryInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 use ZfcUser\Form;
 
 class Login implements FactoryInterface

--- a/src/ZfcUser/Factory/Form/Register.php
+++ b/src/ZfcUser/Factory/Form/Register.php
@@ -3,7 +3,7 @@
 namespace ZfcUser\Factory\Form;
 
 use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\Factory\FactoryInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 use ZfcUser\Form;
 use ZfcUser\Validator;
 

--- a/src/ZfcUser/Factory/Mapper/User.php
+++ b/src/ZfcUser/Factory/Mapper/User.php
@@ -3,8 +3,8 @@
 namespace ZfcUser\Factory\Mapper;
 
 use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\Factory\FactoryInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Laminas\ServiceManager\ServiceLocatorInterface;
 use ZfcUser\Mapper;
 use ZfcUser\Options\ModuleOptions;
 

--- a/src/ZfcUser/Factory/Options/ModuleOptions.php
+++ b/src/ZfcUser/Factory/Options/ModuleOptions.php
@@ -3,8 +3,8 @@
 namespace ZfcUser\Factory\Options;
 
 use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\Factory\FactoryInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Laminas\ServiceManager\ServiceLocatorInterface;
 use ZfcUser\Options;
 
 class ModuleOptions implements FactoryInterface

--- a/src/ZfcUser/Factory/Service/UserFactory.php
+++ b/src/ZfcUser/Factory/Service/UserFactory.php
@@ -3,8 +3,8 @@
 namespace ZfcUser\Factory\Service;
 
 use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\Factory\FactoryInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Laminas\ServiceManager\ServiceLocatorInterface;
 use ZfcUser\Service\User;
 
 class UserFactory implements FactoryInterface

--- a/src/ZfcUser/Factory/UserHydrator.php
+++ b/src/ZfcUser/Factory/UserHydrator.php
@@ -3,14 +3,14 @@
 namespace ZfcUser\Factory;
 
 use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\Factory\FactoryInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Laminas\ServiceManager\ServiceLocatorInterface;
 
 class UserHydrator implements FactoryInterface
 {
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
-        return new \Zend\Hydrator\ClassMethods();
+        return new \Laminas\Hydrator\ClassMethods();
     }
 
 

--- a/src/ZfcUser/Factory/View/Helper/ZfcUserDisplayName.php
+++ b/src/ZfcUser/Factory/View/Helper/ZfcUserDisplayName.php
@@ -3,7 +3,7 @@
 namespace ZfcUser\Factory\View\Helper;
 
 use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\Factory\FactoryInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 use ZfcUser\View;
 
 class ZfcUserDisplayName implements FactoryInterface

--- a/src/ZfcUser/Factory/View/Helper/ZfcUserIdentity.php
+++ b/src/ZfcUser/Factory/View/Helper/ZfcUserIdentity.php
@@ -3,7 +3,7 @@
 namespace ZfcUser\Factory\View\Helper;
 
 use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\Factory\FactoryInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 use ZfcUser\View;
 
 class ZfcUserIdentity implements FactoryInterface

--- a/src/ZfcUser/Factory/View/Helper/ZfcUserLoginWidget.php
+++ b/src/ZfcUser/Factory/View/Helper/ZfcUserLoginWidget.php
@@ -3,7 +3,7 @@
 namespace ZfcUser\Factory\View\Helper;
 
 use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\Factory\FactoryInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 use ZfcUser\View;
 
 class ZfcUserLoginWidget implements FactoryInterface

--- a/src/ZfcUser/Form/Base.php
+++ b/src/ZfcUser/Form/Base.php
@@ -2,7 +2,7 @@
 
 namespace ZfcUser\Form;
 
-use Zend\Form\Element;
+use Laminas\Form\Element;
 
 class Base extends ProvidesEventsForm
 {
@@ -75,7 +75,7 @@ class Base extends ProvidesEventsForm
 
         $this->add(array(
             'name' => 'userId',
-            'type' => 'Zend\Form\Element\Hidden',
+            'type' => 'Laminas\Form\Element\Hidden',
             'attributes' => array(
                 'type' => 'hidden'
             ),

--- a/src/ZfcUser/Form/ChangeEmailFilter.php
+++ b/src/ZfcUser/Form/ChangeEmailFilter.php
@@ -2,7 +2,7 @@
 
 namespace ZfcUser\Form;
 
-use Zend\InputFilter\InputFilter;
+use Laminas\InputFilter\InputFilter;
 use ZfcUser\Options\AuthenticationOptionsInterface;
 
 class ChangeEmailFilter extends InputFilter

--- a/src/ZfcUser/Form/ChangePasswordFilter.php
+++ b/src/ZfcUser/Form/ChangePasswordFilter.php
@@ -2,7 +2,7 @@
 
 namespace ZfcUser\Form;
 
-use Zend\InputFilter\InputFilter;
+use Laminas\InputFilter\InputFilter;
 use ZfcUser\Options\AuthenticationOptionsInterface;
 
 class ChangePasswordFilter extends InputFilter

--- a/src/ZfcUser/Form/Login.php
+++ b/src/ZfcUser/Form/Login.php
@@ -47,14 +47,26 @@ class Login extends ProvidesEventsForm
             ),
         ));
 
-        // @todo: Fix this
-        // 1) getValidator() is a protected method
-        // 2) i don't believe the login form is actually being validated by the login action
-        // (but keep in mind we don't want to show invalid username vs invalid password or
-        // anything like that, it should just say "login failed" without any additional info)
-        //$csrf = new Element\Csrf('csrf');
-        //$csrf->getValidator()->setTimeout($options->getLoginFormTimeout());
-        //$this->add($csrf);
+        $this->add([
+            'type' => '\Zend\Form\Element\Csrf',
+            'name' => 'security',
+            'options' => [
+                'csrf_options' => [
+                    'timeout' => $this->getAuthenticationOptions()->getLoginFormTimeout()
+                ]
+            ]
+        ]);
+        
+        if ($this->getAuthenticationOptions()->getUseLoginFormCaptcha()) {
+            $this->add(array(
+                'name' => 'captcha',
+                'type' => 'Zend\Form\Element\Captcha',
+                'options' => array(
+                    'label' => 'Human check',
+                    'captcha' => $this->getAuthenticationOptions()->getFormCaptchaOptions(),
+                ),
+            ));
+        }
 
         $submitElement = new Element\Button('submit');
         $submitElement

--- a/src/ZfcUser/Form/Login.php
+++ b/src/ZfcUser/Form/Login.php
@@ -2,7 +2,7 @@
 
 namespace ZfcUser\Form;
 
-use Zend\Form\Element;
+use Laminas\Form\Element;
 use ZfcUser\Options\AuthenticationOptionsInterface;
 
 class Login extends ProvidesEventsForm
@@ -49,7 +49,7 @@ class Login extends ProvidesEventsForm
 
         if ($this->getAuthenticationOptions()->getUseLoginFormCsrf()) {
             $this->add([
-                'type' => '\Zend\Form\Element\Csrf',
+                'type' => '\Laminas\Form\Element\Csrf',
                 'name' => 'security',
                 'options' => [
                     'csrf_options' => [
@@ -61,7 +61,7 @@ class Login extends ProvidesEventsForm
         if ($this->getAuthenticationOptions()->getUseLoginFormCaptcha()) {
             $this->add(array(
                 'name' => 'captcha',
-                'type' => 'Zend\Form\Element\Captcha',
+                'type' => 'Laminas\Form\Element\Captcha',
                 'options' => array(
                     'label' => 'Human check',
                     'captcha' => $this->getAuthenticationOptions()->getFormCaptchaOptions(),

--- a/src/ZfcUser/Form/Login.php
+++ b/src/ZfcUser/Form/Login.php
@@ -47,16 +47,17 @@ class Login extends ProvidesEventsForm
             ),
         ));
 
-        $this->add([
-            'type' => '\Zend\Form\Element\Csrf',
-            'name' => 'security',
-            'options' => [
-                'csrf_options' => [
-                    'timeout' => $this->getAuthenticationOptions()->getLoginFormTimeout()
+        if ($this->getAuthenticationOptions()->getUseLoginFormCsrf()) {
+            $this->add([
+                'type' => '\Zend\Form\Element\Csrf',
+                'name' => 'security',
+                'options' => [
+                    'csrf_options' => [
+                        'timeout' => $this->getAuthenticationOptions()->getLoginFormTimeout()
+                    ]
                 ]
-            ]
-        ]);
-        
+            ]);
+        }
         if ($this->getAuthenticationOptions()->getUseLoginFormCaptcha()) {
             $this->add(array(
                 'name' => 'captcha',

--- a/src/ZfcUser/Form/LoginFilter.php
+++ b/src/ZfcUser/Form/LoginFilter.php
@@ -12,7 +12,10 @@ class LoginFilter extends ProvidesEventsInputFilter
         $identityParams = array(
             'name'       => 'identity',
             'required'   => true,
-            'validators' => array()
+            'validators' => array(),
+            'filters'   => array(
+                array('name' => 'StringTrim'),
+            ),
         );
 
         $identityFields = $options->getAuthIdentityFields();

--- a/src/ZfcUser/Form/ProvidesEventsForm.php
+++ b/src/ZfcUser/Form/ProvidesEventsForm.php
@@ -1,8 +1,8 @@
 <?php
 namespace ZfcUser\Form;
 
-use Zend\EventManager\EventManagerAwareTrait;
-use Zend\Form\Form;
+use Laminas\EventManager\EventManagerAwareTrait;
+use Laminas\Form\Form;
 
 class ProvidesEventsForm extends Form
 {

--- a/src/ZfcUser/Form/Register.php
+++ b/src/ZfcUser/Form/Register.php
@@ -2,7 +2,7 @@
 
 namespace ZfcUser\Form;
 
-use Zend\Form\Element\Captcha as Captcha;
+use Laminas\Form\Element\Captcha as Captcha;
 use ZfcUser\Options\RegistrationOptionsInterface;
 
 class Register extends Base
@@ -27,7 +27,7 @@ class Register extends Base
         if ($this->getRegistrationOptions()->getUseRegistrationFormCaptcha()) {
             $this->add(array(
                 'name' => 'captcha',
-                'type' => 'Zend\Form\Element\Captcha',
+                'type' => 'Laminas\Form\Element\Captcha',
                 'options' => array(
                     'label' => 'Please type the following text',
                     'captcha' => $this->getRegistrationOptions()->getFormCaptchaOptions(),

--- a/src/ZfcUser/InputFilter/ProvidesEventsInputFilter.php
+++ b/src/ZfcUser/InputFilter/ProvidesEventsInputFilter.php
@@ -1,8 +1,8 @@
 <?php
 namespace ZfcUser\InputFilter;
 
-use Zend\EventManager\EventManagerAwareTrait;
-use Zend\InputFilter\InputFilter;
+use Laminas\EventManager\EventManagerAwareTrait;
+use Laminas\InputFilter\InputFilter;
 
 class ProvidesEventsInputFilter extends InputFilter
 {

--- a/src/ZfcUser/Mapper/AbstractDbMapper.php
+++ b/src/ZfcUser/Mapper/AbstractDbMapper.php
@@ -1,14 +1,14 @@
 <?php
 namespace ZfcUser\Mapper;
 
-use Zend\Db\Adapter\Adapter;
-use Zend\Db\Adapter\Driver\ResultInterface;
-use Zend\Db\ResultSet\HydratingResultSet;
-use Zend\Db\Sql\Select;
-use Zend\Db\Sql\Sql;
-use Zend\Db\Sql\TableIdentifier;
-use Zend\Hydrator\HydratorInterface;
-use Zend\Hydrator\ClassMethods;
+use Laminas\Db\Adapter\Adapter;
+use Laminas\Db\Adapter\Driver\ResultInterface;
+use Laminas\Db\ResultSet\HydratingResultSet;
+use Laminas\Db\Sql\Select;
+use Laminas\Db\Sql\Sql;
+use Laminas\Db\Sql\TableIdentifier;
+use Laminas\Hydrator\HydratorInterface;
+use Laminas\Hydrator\ClassMethods;
 use ZfcUser\Entity\UserInterface as UserEntityInterface;
 use ZfcUser\EventManager\EventProvider;
 use ZfcUser\Db\Adapter\MasterSlaveAdapterInterface;

--- a/src/ZfcUser/Mapper/User.php
+++ b/src/ZfcUser/Mapper/User.php
@@ -3,7 +3,7 @@
 namespace ZfcUser\Mapper;
 
 use ZfcUser\Entity\UserInterface as UserEntityInterface;
-use Zend\Hydrator\HydratorInterface;
+use Laminas\Hydrator\HydratorInterface;
 
 class User extends AbstractDbMapper implements UserInterface
 {

--- a/src/ZfcUser/Mapper/UserHydrator.php
+++ b/src/ZfcUser/Mapper/UserHydrator.php
@@ -2,7 +2,7 @@
 
 namespace ZfcUser\Mapper;
 
-use Zend\Hydrator\ClassMethods;
+use Laminas\Hydrator\ClassMethods;
 use ZfcUser\Entity\UserInterface as UserEntityInterface;
 
 class UserHydrator extends ClassMethods

--- a/src/ZfcUser/Options/AuthenticationOptionsInterface.php
+++ b/src/ZfcUser/Options/AuthenticationOptionsInterface.php
@@ -33,4 +33,34 @@ interface AuthenticationOptionsInterface extends PasswordOptionsInterface
      * @return array
      */
     public function getAuthIdentityFields();
+    
+    /**
+     * set use a captcha in registration form
+     *
+     * @param bool $useRegistrationFormCaptcha
+     * @return ModuleOptions
+     */
+    public function setUseLoginFormCaptcha($useRegistrationFormCaptcha);
+    
+    /**
+     * get use a captcha in registration form
+     *
+     * @return bool
+     */
+    public function getUseLoginFormCaptcha();
+    
+    /**
+     * set form CAPTCHA options
+     *
+     * @param array $formCaptchaOptions
+     * @return ModuleOptions
+     */
+    public function setFormCaptchaOptions($formCaptchaOptions);
+    
+    /**
+     * get form CAPTCHA options
+     *
+     * @return array
+     */
+    public function getFormCaptchaOptions();
 }

--- a/src/ZfcUser/Options/AuthenticationOptionsInterface.php
+++ b/src/ZfcUser/Options/AuthenticationOptionsInterface.php
@@ -50,6 +50,21 @@ interface AuthenticationOptionsInterface extends PasswordOptionsInterface
     public function getUseLoginFormCaptcha();
     
     /**
+     * set use a csrf in login form
+     *
+     * @param bool $useRegistrationFormCaptcha
+     * @return ModuleOptions
+     */
+    public function setUseLoginFormCsrf($useLoginFormCsrf);
+    
+    /**
+     * get use a csrf in login form
+     *
+     * @return bool
+     */
+    public function getUseLoginFormCsrf();
+    
+    /**
      * set form CAPTCHA options
      *
      * @param array $formCaptchaOptions

--- a/src/ZfcUser/Options/ModuleOptions.php
+++ b/src/ZfcUser/Options/ModuleOptions.php
@@ -102,6 +102,11 @@ class ModuleOptions extends AbstractOptions implements
      * @var bool
      */
     protected $useLoginFormCaptcha = false;
+    
+    /**
+     * @var bool
+     */
+    protected $useLoginFormCsrf = true;
 
     /**
      * @var int
@@ -498,6 +503,28 @@ class ModuleOptions extends AbstractOptions implements
     public function getUseLoginFormCaptcha()
     {
         return $this->useLoginFormCaptcha;
+    }
+    
+    /**
+     * set use a csrf in login form
+     *
+     * @param bool $useRegistrationFormCaptcha
+     * @return ModuleOptions
+     */
+    public function setUseLoginFormCsrf($useLoginFormCsrf)
+    {
+        $this->useLoginFormCsrf = $useLoginFormCsrf;
+        return $this;
+    }
+    
+    /**
+     * get use a csrf in login form
+     *
+     * @return bool
+     */
+    public function getUseLoginFormCsrf()
+    {
+        return $this->useLoginFormCsrf;
     }
 
     /**

--- a/src/ZfcUser/Options/ModuleOptions.php
+++ b/src/ZfcUser/Options/ModuleOptions.php
@@ -97,6 +97,11 @@ class ModuleOptions extends AbstractOptions implements
      * @var bool
      */
     protected $useRegistrationFormCaptcha = false;
+    
+    /**
+     * @var bool
+     */
+    protected $useLoginFormCaptcha = false;
 
     /**
      * @var int
@@ -471,6 +476,28 @@ class ModuleOptions extends AbstractOptions implements
     public function getUseRegistrationFormCaptcha()
     {
         return $this->useRegistrationFormCaptcha;
+    }
+    
+    /**
+     * set use a captcha in login form
+     *
+     * @param bool $useRegistrationFormCaptcha
+     * @return ModuleOptions
+     */
+    public function setUseLoginFormCaptcha($useLoginFormCaptcha)
+    {
+        $this->useLoginFormCaptcha = $useLoginFormCaptcha;
+        return $this;
+    }
+    
+    /**
+     * get use a captcha in login form
+     *
+     * @return bool
+     */
+    public function getUseLoginFormCaptcha()
+    {
+        return $this->useLoginFormCaptcha;
     }
 
     /**

--- a/src/ZfcUser/Options/ModuleOptions.php
+++ b/src/ZfcUser/Options/ModuleOptions.php
@@ -2,7 +2,7 @@
 
 namespace ZfcUser\Options;
 
-use Zend\Stdlib\AbstractOptions;
+use Laminas\Stdlib\AbstractOptions;
 
 class ModuleOptions extends AbstractOptions implements
     UserControllerOptionsInterface,

--- a/src/ZfcUser/Service/User.php
+++ b/src/ZfcUser/Service/User.php
@@ -3,11 +3,11 @@
 namespace ZfcUser\Service;
 
 use Interop\Container\ContainerInterface;
-use Zend\Authentication\AuthenticationService;
-use Zend\Form\Form;
-use Zend\ServiceManager\ServiceManager;
-use Zend\Crypt\Password\Bcrypt;
-use Zend\Hydrator;
+use Laminas\Authentication\AuthenticationService;
+use Laminas\Form\Form;
+use Laminas\ServiceManager\ServiceManager;
+use Laminas\Crypt\Password\Bcrypt;
+use Laminas\Hydrator;
 use ZfcUser\EventManager\EventProvider;
 use ZfcUser\Mapper\UserInterface as UserMapperInterface;
 use ZfcUser\Options\UserServiceOptionsInterface;
@@ -288,7 +288,7 @@ class User extends EventProvider
     /**
      * Return the Form Hydrator
      *
-     * @return \Zend\Hydrator\ClassMethods
+     * @return \Laminas\Hydrator\ClassMethods
      */
     public function getFormHydrator()
     {

--- a/src/ZfcUser/Validator/AbstractRecord.php
+++ b/src/ZfcUser/Validator/AbstractRecord.php
@@ -2,7 +2,7 @@
 
 namespace ZfcUser\Validator;
 
-use Zend\Validator\AbstractValidator;
+use Laminas\Validator\AbstractValidator;
 use ZfcUser\Mapper\UserInterface;
 
 abstract class AbstractRecord extends AbstractValidator

--- a/src/ZfcUser/View/Helper/ZfcUserDisplayName.php
+++ b/src/ZfcUser/View/Helper/ZfcUserDisplayName.php
@@ -2,8 +2,8 @@
 
 namespace ZfcUser\View\Helper;
 
-use Zend\View\Helper\AbstractHelper;
-use Zend\Authentication\AuthenticationService;
+use Laminas\View\Helper\AbstractHelper;
+use Laminas\Authentication\AuthenticationService;
 use ZfcUser\Entity\UserInterface as User;
 
 class ZfcUserDisplayName extends AbstractHelper

--- a/src/ZfcUser/View/Helper/ZfcUserIdentity.php
+++ b/src/ZfcUser/View/Helper/ZfcUserIdentity.php
@@ -2,8 +2,8 @@
 
 namespace ZfcUser\View\Helper;
 
-use Zend\View\Helper\AbstractHelper;
-use Zend\Authentication\AuthenticationService;
+use Laminas\View\Helper\AbstractHelper;
+use Laminas\Authentication\AuthenticationService;
 
 class ZfcUserIdentity extends AbstractHelper
 {

--- a/src/ZfcUser/View/Helper/ZfcUserLoginWidget.php
+++ b/src/ZfcUser/View/Helper/ZfcUserLoginWidget.php
@@ -2,9 +2,9 @@
 
 namespace ZfcUser\View\Helper;
 
-use Zend\View\Helper\AbstractHelper;
+use Laminas\View\Helper\AbstractHelper;
 use ZfcUser\Form\Login as LoginForm;
-use Zend\View\Model\ViewModel;
+use Laminas\View\Model\ViewModel;
 
 class ZfcUserLoginWidget extends AbstractHelper
 {

--- a/tests/ZfcUserTest/Authentication/Adapter/AbstractAdapterTest.php
+++ b/tests/ZfcUserTest/Authentication/Adapter/AbstractAdapterTest.php
@@ -23,7 +23,7 @@ class AbstractAdapterTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetStorageWithoutStorageSet()
     {
-        $this->assertInstanceOf('Zend\Authentication\Storage\Session', $this->adapter->getStorage());
+        $this->assertInstanceOf('Laminas\Authentication\Storage\Session', $this->adapter->getStorage());
     }
 
     /**
@@ -32,11 +32,11 @@ class AbstractAdapterTest extends \PHPUnit_Framework_TestCase
      */
     public function testSetGetStorage()
     {
-        $storage = new \Zend\Authentication\Storage\Session('ZfcUser');
+        $storage = new \Laminas\Authentication\Storage\Session('ZfcUser');
         $storage->write('zfcUser');
         $this->adapter->setStorage($storage);
 
-        $this->assertInstanceOf('Zend\Authentication\Storage\Session', $this->adapter->getStorage());
+        $this->assertInstanceOf('Laminas\Authentication\Storage\Session', $this->adapter->getStorage());
         $this->assertSame('zfcUser', $this->adapter->getStorage()->read());
     }
 

--- a/tests/ZfcUserTest/Authentication/Adapter/AdapterChainEventTest.php
+++ b/tests/ZfcUserTest/Authentication/Adapter/AdapterChainEventTest.php
@@ -68,9 +68,9 @@ class AdapterChainEventTest extends \PHPUnit_Framework_TestCase
 
     public function testRequest()
     {
-        $request = $this->getMock('Zend\Stdlib\RequestInterface');
+        $request = $this->getMock('Laminas\Stdlib\RequestInterface');
         $this->event->setRequest($request);
 
-        $this->assertInstanceOf('Zend\Stdlib\RequestInterface', $this->event->getRequest());
+        $this->assertInstanceOf('Laminas\Stdlib\RequestInterface', $this->event->getRequest());
     }
 }

--- a/tests/ZfcUserTest/Authentication/Adapter/AdapterChainServiceFactoryTest.php
+++ b/tests/ZfcUserTest/Authentication/Adapter/AdapterChainServiceFactoryTest.php
@@ -14,7 +14,7 @@ class AdapterChainServiceFactoryTest extends \PHPUnit_Framework_TestCase
     protected $factory;
 
     /**
-     * @var \Zend\ServiceManager\ServiceLocatorInterface
+     * @var \Laminas\ServiceManager\ServiceLocatorInterface
      */
     protected $serviceLocator;
 
@@ -24,7 +24,7 @@ class AdapterChainServiceFactoryTest extends \PHPUnit_Framework_TestCase
     protected $options;
 
     /**
-     * @var \Zend\EventManager\EventManagerInterface
+     * @var \Laminas\EventManager\EventManagerInterface
      */
     protected $eventManager;
 
@@ -41,7 +41,7 @@ class AdapterChainServiceFactoryTest extends \PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-        $this->serviceLocator = $this->getMock('Zend\ServiceManager\ServiceLocatorInterface');
+        $this->serviceLocator = $this->getMock('Laminas\ServiceManager\ServiceLocatorInterface');
 
         $this->options = $this->getMockBuilder('ZfcUser\Options\ModuleOptions')
             ->disableOriginalConstructor()
@@ -55,7 +55,7 @@ class AdapterChainServiceFactoryTest extends \PHPUnit_Framework_TestCase
             ->method('get')
             ->will($this->returnCallback(array($this,'helperServiceLocator')));
 
-        $this->eventManager = $this->getMock('Zend\EventManager\EventManager');
+        $this->eventManager = $this->getMock('Laminas\EventManager\EventManager');
 
         $this->factory = new AdapterChainServiceFactory();
     }

--- a/tests/ZfcUserTest/Authentication/Adapter/AdapterChainTest.php
+++ b/tests/ZfcUserTest/Authentication/Adapter/AdapterChainTest.php
@@ -2,12 +2,12 @@
 
 namespace ZfcUserTest\Authentication\Adapter;
 
-use Zend\EventManager\EventInterface;
-use Zend\EventManager\EventManagerInterface;
-use Zend\EventManager\SharedEventManagerInterface;
+use Laminas\EventManager\EventInterface;
+use Laminas\EventManager\EventManagerInterface;
+use Laminas\EventManager\SharedEventManagerInterface;
 use ZfcUser\Authentication\Adapter\AdapterChain;
 use ZfcUser\Authentication\Adapter\AdapterChainEvent;
-use Zend\Stdlib\RequestInterface;
+use Laminas\Stdlib\RequestInterface;
 
 class AdapterChainTest extends \PHPUnit_Framework_TestCase
 {
@@ -56,10 +56,10 @@ class AdapterChainTest extends \PHPUnit_Framework_TestCase
 
         $this->adapterChain = new AdapterChain();
 
-        $this->sharedEventManager = $this->getMock('Zend\EventManager\SharedEventManagerInterface');
+        $this->sharedEventManager = $this->getMock('Laminas\EventManager\SharedEventManagerInterface');
         //$this->sharedEventManager->expects($this->any())->method('getListeners')->will($this->returnValue([]));
 
-        $this->eventManager = $this->getMock('Zend\EventManager\EventManagerInterface');
+        $this->eventManager = $this->getMock('Laminas\EventManager\EventManagerInterface');
         $this->eventManager->expects($this->any())->method('getSharedManager')->will($this->returnValue($this->sharedEventManager));
         $this->eventManager->expects($this->any())->method('setIdentifiers');
 
@@ -90,7 +90,7 @@ class AdapterChainTest extends \PHPUnit_Framework_TestCase
         $this->adapterChain->setEvent($event);
         $result = $this->adapterChain->authenticate();
 
-        $this->assertInstanceOf('Zend\Authentication\Result', $result);
+        $this->assertInstanceOf('Laminas\Authentication\Result', $result);
         $this->assertEquals($result->getIdentity(), 'identity');
         $this->assertEquals($result->getMessages(), array());
     }
@@ -131,7 +131,7 @@ class AdapterChainTest extends \PHPUnit_Framework_TestCase
      */
     protected function setUpPrepareForAuthentication()
     {
-        $this->request = $this->getMock('Zend\Stdlib\RequestInterface');
+        $this->request = $this->getMock('Laminas\Stdlib\RequestInterface');
         $this->event = $this->getMock('ZfcUser\Authentication\Adapter\AdapterChainEvent');
 
         $this->event->expects($this->once())->method('setRequest')->with($this->request);
@@ -139,9 +139,9 @@ class AdapterChainTest extends \PHPUnit_Framework_TestCase
         $this->eventManager->expects($this->at(0))->method('trigger')->with('authenticate.pre');
 
         /**
-         * @var $response \Zend\EventManager\ResponseCollection
+         * @var $response \Laminas\EventManager\ResponseCollection
          */
-        $responses = $this->getMock('Zend\EventManager\ResponseCollection');
+        $responses = $this->getMock('Laminas\EventManager\ResponseCollection');
 
         $this->eventManager->expects($this->at(1))
             ->method('trigger')
@@ -206,7 +206,7 @@ class AdapterChainTest extends \PHPUnit_Framework_TestCase
 
         $result->expects($this->once())->method('stopped')->will($this->returnValue(true));
 
-        $lastResponse = $this->getMock('Zend\Stdlib\ResponseInterface');
+        $lastResponse = $this->getMock('Laminas\Stdlib\ResponseInterface');
         $result->expects($this->atLeastOnce())->method('last')->will($this->returnValue($lastResponse));
 
         $this->assertEquals(
@@ -283,7 +283,7 @@ class AdapterChainTest extends \PHPUnit_Framework_TestCase
     {
         $testParams = array('testParam' => 'testValue');
 
-        $event = new \Zend\EventManager\Event;
+        $event = new \Laminas\EventManager\Event;
         $event->setParams($testParams);
 
         $this->adapterChain->setEvent($event);

--- a/tests/ZfcUserTest/Authentication/Adapter/DbTest.php
+++ b/tests/ZfcUserTest/Authentication/Adapter/DbTest.php
@@ -2,7 +2,7 @@
 
 namespace ZfcUserTest\Authentication\Adapter;
 
-use Zend\EventManager\Event;
+use Laminas\EventManager\Event;
 use ZfcUser\Authentication\Adapter\Db;
 
 class DbTest extends \PHPUnit_Framework_TestCase
@@ -24,7 +24,7 @@ class DbTest extends \PHPUnit_Framework_TestCase
     /**
      * Mock of Storage.
      *
-     * @var \Zend\Authentication\Storage\Session|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Laminas\Authentication\Storage\Session|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $storage;
 
@@ -51,7 +51,7 @@ class DbTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $storage = $this->getMock('Zend\Authentication\Storage\Session');
+        $storage = $this->getMock('Laminas\Authentication\Storage\Session');
         $this->storage = $storage;
 
         $authEvent = $this->getMock('ZfcUser\Authentication\Adapter\AdapterChainEvent');
@@ -69,8 +69,8 @@ class DbTest extends \PHPUnit_Framework_TestCase
         $this->db = new Db;
         $this->db->setStorage($this->storage);
 
-        $sessionManager = $this->getMock('Zend\Session\SessionManager');
-        \Zend\Session\AbstractContainer::setDefaultManager($sessionManager);
+        $sessionManager = $this->getMock('Laminas\Session\SessionManager');
+        \Laminas\Session\AbstractContainer::setDefaultManager($sessionManager);
     }
 
     /**
@@ -95,7 +95,7 @@ class DbTest extends \PHPUnit_Framework_TestCase
                         ->will($this->returnValue($this->authEvent));
         $this->authEvent->expects($this->once())
                         ->method('setCode')
-                        ->with(\Zend\Authentication\Result::SUCCESS)
+                        ->with(\Laminas\Authentication\Result::SUCCESS)
                         ->will($this->returnValue($this->authEvent));
         $this->authEvent->expects($this->once())
                         ->method('setMessages')
@@ -128,7 +128,7 @@ class DbTest extends \PHPUnit_Framework_TestCase
 
         $this->authEvent->expects($this->once())
             ->method('setCode')
-            ->with(\Zend\Authentication\Result::FAILURE_IDENTITY_NOT_FOUND)
+            ->with(\Laminas\Authentication\Result::FAILURE_IDENTITY_NOT_FOUND)
             ->will($this->returnValue($this->authEvent));
         $this->authEvent->expects($this->once())
             ->method('setMessages')
@@ -161,7 +161,7 @@ class DbTest extends \PHPUnit_Framework_TestCase
 
         $this->authEvent->expects($this->once())
             ->method('setCode')
-            ->with(\Zend\Authentication\Result::FAILURE_UNCATEGORIZED)
+            ->with(\Laminas\Authentication\Result::FAILURE_UNCATEGORIZED)
             ->will($this->returnValue($this->authEvent));
         $this->authEvent->expects($this->once())
             ->method('setMessages')
@@ -201,7 +201,7 @@ class DbTest extends \PHPUnit_Framework_TestCase
 
         $this->authEvent->expects($this->once())
             ->method('setCode')
-            ->with(\Zend\Authentication\Result::FAILURE_CREDENTIAL_INVALID)
+            ->with(\Laminas\Authentication\Result::FAILURE_CREDENTIAL_INVALID)
             ->will($this->returnValue($this->authEvent));
         $this->authEvent->expects($this->once(1))
             ->method('setMessages')
@@ -250,7 +250,7 @@ class DbTest extends \PHPUnit_Framework_TestCase
                         ->will($this->returnValue($this->authEvent));
         $this->authEvent->expects($this->once())
                         ->method('setCode')
-                        ->with(\Zend\Authentication\Result::SUCCESS)
+                        ->with(\Laminas\Authentication\Result::SUCCESS)
                         ->will($this->returnValue($this->authEvent));
         $this->authEvent->expects($this->once())
                         ->method('setMessages')
@@ -304,7 +304,7 @@ class DbTest extends \PHPUnit_Framework_TestCase
                         ->will($this->returnValue($this->authEvent));
         $this->authEvent->expects($this->once())
                         ->method('setCode')
-                        ->with(\Zend\Authentication\Result::SUCCESS)
+                        ->with(\Laminas\Authentication\Result::SUCCESS)
                         ->will($this->returnValue($this->authEvent));
         $this->authEvent->expects($this->once())
                         ->method('setMessages')
@@ -328,7 +328,7 @@ class DbTest extends \PHPUnit_Framework_TestCase
             ->method('getPassword')
             ->will($this->returnValue('$2a$10$x05G2P803MrB3jaORBXBn.QHtiYzGQOBjQ7unpEIge.Mrz6c3KiVm'));
 
-        $bcrypt = $this->getMock('Zend\Crypt\Password\Bcrypt');
+        $bcrypt = $this->getMock('Laminas\Crypt\Password\Bcrypt');
         $bcrypt->expects($this->once())
             ->method('getCost')
             ->will($this->returnValue('10'));
@@ -356,7 +356,7 @@ class DbTest extends \PHPUnit_Framework_TestCase
             ->method('setPassword')
             ->with('$2a$10$D41KPuDCn6iGoESjnLee/uE/2Xo985sotVySo2HKDz6gAO4hO/Gh6');
 
-        $bcrypt = $this->getMock('Zend\Crypt\Password\Bcrypt');
+        $bcrypt = $this->getMock('Laminas\Crypt\Password\Bcrypt');
         $bcrypt->expects($this->once())
             ->method('getCost')
             ->will($this->returnValue('5'));
@@ -419,13 +419,13 @@ class DbTest extends \PHPUnit_Framework_TestCase
      */
     public function testSetGetServicemanager()
     {
-        $sm = $this->getMock('Zend\ServiceManager\ServiceManager');
+        $sm = $this->getMock('Laminas\ServiceManager\ServiceManager');
 
         $this->db->setServiceManager($sm);
 
         $serviceManager = $this->db->getServiceManager();
 
-        $this->assertInstanceOf('Zend\ServiceManager\ServiceLocatorInterface', $serviceManager);
+        $this->assertInstanceOf('Laminas\ServiceManager\ServiceLocatorInterface', $serviceManager);
         $this->assertSame($sm, $serviceManager);
     }
 
@@ -434,7 +434,7 @@ class DbTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetOptionsWithNoOptionsSet()
     {
-        $serviceMapper = $this->getMock('Zend\ServiceManager\ServiceManager');
+        $serviceMapper = $this->getMock('Laminas\ServiceManager\ServiceManager');
         $serviceMapper->expects($this->once())
             ->method('get')
             ->with('zfcuser_module_options')
@@ -468,7 +468,7 @@ class DbTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetMapperWithNoMapperSet()
     {
-        $serviceMapper = $this->getMock('Zend\ServiceManager\ServiceManager');
+        $serviceMapper = $this->getMock('Laminas\ServiceManager\ServiceManager');
         $serviceMapper->expects($this->once())
             ->method('get')
             ->with('zfcuser_user_mapper')
@@ -526,7 +526,7 @@ class DbTest extends \PHPUnit_Framework_TestCase
             ->method('read')
             ->will($this->returnValue(array('is_satisfied' => false)));
 
-        $post = $this->getMock('Zend\Stdlib\Parameters');
+        $post = $this->getMock('Laminas\Stdlib\Parameters');
         $post->expects($this->at(0))
             ->method('get')
             ->with('identity')
@@ -536,7 +536,7 @@ class DbTest extends \PHPUnit_Framework_TestCase
             ->with('credential')
             ->will($this->returnValue($credential));
 
-        $request = $this->getMock('Zend\Http\Request');
+        $request = $this->getMock('Laminas\Http\Request');
         $request->expects($this->exactly(2))
             ->method('getPost')
             ->will($this->returnValue($post));

--- a/tests/ZfcUserTest/Authentication/Adapter/TestAsset/AbstractAdapterExtension.php
+++ b/tests/ZfcUserTest/Authentication/Adapter/TestAsset/AbstractAdapterExtension.php
@@ -2,7 +2,7 @@
 
 namespace ZfcUserTest\Authentication\Adapter\TestAsset;
 
-use Zend\EventManager\EventInterface;
+use Laminas\EventManager\EventInterface;
 use ZfcUser\Authentication\Adapter\AbstractAdapter;
 
 class AbstractAdapterExtension extends AbstractAdapter

--- a/tests/ZfcUserTest/Authentication/Storage/DbTest.php
+++ b/tests/ZfcUserTest/Authentication/Storage/DbTest.php
@@ -32,7 +32,7 @@ class DbTest extends \PHPUnit_Framework_TestCase
         $db = new Db;
         $this->db = $db;
 
-        $this->storage = $this->getMock('Zend\Authentication\Storage\Session');
+        $this->storage = $this->getMock('Laminas\Authentication\Storage\Session');
         $this->mapper = $this->getMock('ZfcUser\Mapper\User');
     }
 
@@ -175,7 +175,7 @@ class DbTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetMapperWithNoMapperSet()
     {
-        $sm = $this->getMock('Zend\ServiceManager\ServiceManager');
+        $sm = $this->getMock('Laminas\ServiceManager\ServiceManager');
         $sm->expects($this->once())
            ->method('get')
            ->with('zfcuser_user_mapper')
@@ -207,11 +207,11 @@ class DbTest extends \PHPUnit_Framework_TestCase
      */
     public function testSetGetServicemanager()
     {
-        $sm = $this->getMock('Zend\ServiceManager\ServiceManager');
+        $sm = $this->getMock('Laminas\ServiceManager\ServiceManager');
 
         $this->db->setServiceManager($sm);
 
-        $this->assertInstanceOf('Zend\ServiceManager\ServiceLocatorInterface', $this->db->getServiceManager());
+        $this->assertInstanceOf('Laminas\ServiceManager\ServiceLocatorInterface', $this->db->getServiceManager());
         $this->assertSame($sm, $this->db->getServiceManager());
     }
 
@@ -221,7 +221,7 @@ class DbTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetStorageWithoutStorageSet()
     {
-        $this->assertInstanceOf('Zend\Authentication\Storage\Session', $this->db->getStorage());
+        $this->assertInstanceOf('Laminas\Authentication\Storage\Session', $this->db->getStorage());
     }
 
     /**
@@ -230,9 +230,9 @@ class DbTest extends \PHPUnit_Framework_TestCase
      */
     public function testSetGetStorage()
     {
-        $storage = new \Zend\Authentication\Storage\Session('ZfcUserStorage');
+        $storage = new \Laminas\Authentication\Storage\Session('ZfcUserStorage');
         $this->db->setStorage($storage);
 
-        $this->assertInstanceOf('Zend\Authentication\Storage\Session', $this->db->getStorage());
+        $this->assertInstanceOf('Laminas\Authentication\Storage\Session', $this->db->getStorage());
     }
 }

--- a/tests/ZfcUserTest/Controller/Plugin/ZfcUserAuthenticationTest.php
+++ b/tests/ZfcUserTest/Controller/Plugin/ZfcUserAuthenticationTest.php
@@ -3,8 +3,8 @@
 namespace ZfcUserTest\Controller\Plugin;
 
 use ZfcUser\Controller\Plugin\ZfcUserAuthentication as Plugin;
-use Zend\Authentication\AuthenticationService;
-use Zend\Authentication\Adapter\AdapterInterface;
+use Laminas\Authentication\AuthenticationService;
+use Laminas\Authentication\Adapter\AdapterInterface;
 use ZfcUser\Authentication\Adapter\AdapterChain;
 
 class ZfcUserAuthenticationTest extends \PHPUnit_Framework_TestCase
@@ -30,7 +30,7 @@ class ZfcUserAuthenticationTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->SUT = new Plugin();
-        $this->mockedAuthenticationService = $this->getMock('Zend\Authentication\AuthenticationService');
+        $this->mockedAuthenticationService = $this->getMock('Laminas\Authentication\AuthenticationService');
         $this->mockedAuthenticationAdapter = $this->getMockForAbstractClass('\ZfcUser\Authentication\Adapter\AdapterChain');
     }
 
@@ -78,12 +78,12 @@ class ZfcUserAuthenticationTest extends \PHPUnit_Framework_TestCase
         $adapter2 = new AdapterChain();
         $this->SUT->setAuthAdapter($adapter1);
 
-        $this->assertInstanceOf('\Zend\Authentication\Adapter\AdapterInterface', $this->SUT->getAuthAdapter());
+        $this->assertInstanceOf('\Laminas\Authentication\Adapter\AdapterInterface', $this->SUT->getAuthAdapter());
         $this->assertSame($adapter1, $this->SUT->getAuthAdapter());
 
         $this->SUT->setAuthAdapter($adapter2);
 
-        $this->assertInstanceOf('\Zend\Authentication\Adapter\AdapterInterface', $this->SUT->getAuthAdapter());
+        $this->assertInstanceOf('\Laminas\Authentication\Adapter\AdapterInterface', $this->SUT->getAuthAdapter());
         $this->assertNotSame($adapter1, $this->SUT->getAuthAdapter());
         $this->assertSame($adapter2, $this->SUT->getAuthAdapter());
     }
@@ -98,12 +98,12 @@ class ZfcUserAuthenticationTest extends \PHPUnit_Framework_TestCase
         $service2 = new AuthenticationService();
         $this->SUT->setAuthService($service1);
 
-        $this->assertInstanceOf('\Zend\Authentication\AuthenticationService', $this->SUT->getAuthService());
+        $this->assertInstanceOf('\Laminas\Authentication\AuthenticationService', $this->SUT->getAuthService());
         $this->assertSame($service1, $this->SUT->getAuthService());
 
         $this->SUT->setAuthService($service2);
 
-        $this->assertInstanceOf('\Zend\Authentication\AuthenticationService', $this->SUT->getAuthService());
+        $this->assertInstanceOf('\Laminas\Authentication\AuthenticationService', $this->SUT->getAuthService());
         $this->assertNotSame($service1, $this->SUT->getAuthService());
         $this->assertSame($service2, $this->SUT->getAuthService());
     }

--- a/tests/ZfcUserTest/Controller/RedirectCallbackTest.php
+++ b/tests/ZfcUserTest/Controller/RedirectCallbackTest.php
@@ -2,12 +2,12 @@
 
 namespace ZfcUserTest\Controller;
 
-use Zend\Http\PhpEnvironment\Request;
-use Zend\Http\PhpEnvironment\Response;
-use Zend\Mvc\Application;
-use Zend\Mvc\MvcEvent;
-use Zend\Router\RouteInterface;
-use Zend\Router\RouteMatch;
+use Laminas\Http\PhpEnvironment\Request;
+use Laminas\Http\PhpEnvironment\Response;
+use Laminas\Mvc\Application;
+use Laminas\Mvc\MvcEvent;
+use Laminas\Router\RouteInterface;
+use Laminas\Router\RouteMatch;
 use ZfcUser\Controller\RedirectCallback;
 use ZfcUser\Options\ModuleOptions;
 
@@ -40,7 +40,7 @@ class RedirectCallbackTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->router = $this->getMockBuilder('Zend\Router\RouteInterface')
+        $this->router = $this->getMockBuilder('Laminas\Router\RouteInterface')
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -48,7 +48,7 @@ class RedirectCallbackTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->application = $this->getMockBuilder('Zend\Mvc\Application')
+        $this->application = $this->getMockBuilder('Laminas\Mvc\Application')
             ->disableOriginalConstructor()
             ->getMock();
         $this->setUpApplication();
@@ -68,7 +68,7 @@ class RedirectCallbackTest extends \PHPUnit_Framework_TestCase
             ->method('getMatchedRouteName')
             ->will($this->returnValue('someRoute'));
 
-        $headers = $this->getMock('Zend\Http\Headers');
+        $headers = $this->getMock('Laminas\Http\Headers');
         $headers->expects($this->once())
             ->method('addHeaderLine')
             ->with('Location', $url);
@@ -146,11 +146,11 @@ class RedirectCallbackTest extends \PHPUnit_Framework_TestCase
             array('user', false, $this->returnValue('route'), false),
             array('user', false, $this->returnValue('route'), $this->returnValue(true)),
             array('user', 'user', $this->returnValue('route'), $this->returnValue(true)),
-            array('user', 'user', $this->throwException(new \Zend\Router\Exception\RuntimeException), $this->returnValue(true)),
-            array('user', 'user', $this->throwException(new \Zend\Router\Exception\RuntimeException), $this->throwException(new \Zend\Router\Exception\RuntimeException)),
+            array('user', 'user', $this->throwException(new \Laminas\Router\Exception\RuntimeException), $this->returnValue(true)),
+            array('user', 'user', $this->throwException(new \Laminas\Router\Exception\RuntimeException), $this->throwException(new \Laminas\Router\Exception\RuntimeException)),
             array(false, 'user', false, $this->returnValue(true)),
-            array(false, 'user', false, $this->throwException(new \Zend\Router\Exception\RuntimeException)),
-            array(false, 'user', false, $this->throwException(new \Zend\Router\Exception\RuntimeException)),
+            array(false, 'user', false, $this->throwException(new \Laminas\Router\Exception\RuntimeException)),
+            array(false, 'user', false, $this->throwException(new \Laminas\Router\Exception\RuntimeException)),
         );
     }
 
@@ -179,7 +179,7 @@ class RedirectCallbackTest extends \PHPUnit_Framework_TestCase
         $this->router->expects($this->once())
             ->method('assemble')
             ->with(array(), array('name' => $route))
-            ->will($this->throwException(new \Zend\Router\Exception\RuntimeException));
+            ->will($this->throwException(new \Laminas\Router\Exception\RuntimeException));
 
         $method = new \ReflectionMethod(
             'ZfcUser\Controller\RedirectCallback',
@@ -274,7 +274,7 @@ class RedirectCallbackTest extends \PHPUnit_Framework_TestCase
         $this->router->expects($this->at(0))
             ->method('assemble')
             ->with(array(), array('name' => $redirect))
-            ->will($this->throwException(new \Zend\Router\Exception\RuntimeException));
+            ->will($this->throwException(new \Laminas\Router\Exception\RuntimeException));
 
         $this->router->expects($this->at(1))
             ->method('assemble')
@@ -297,19 +297,19 @@ class RedirectCallbackTest extends \PHPUnit_Framework_TestCase
 
     private function setUpApplication()
     {
-        $this->request = $this->getMockBuilder('Zend\Http\PhpEnvironment\Request')
+        $this->request = $this->getMockBuilder('Laminas\Http\PhpEnvironment\Request')
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->response = $this->getMockBuilder('Zend\Http\PhpEnvironment\Response')
+        $this->response = $this->getMockBuilder('Laminas\Http\PhpEnvironment\Response')
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->routeMatch = $this->getMockBuilder('Zend\Router\RouteMatch')
+        $this->routeMatch = $this->getMockBuilder('Laminas\Router\RouteMatch')
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->mvcEvent = $this->getMockBuilder('Zend\Mvc\MvcEvent')
+        $this->mvcEvent = $this->getMockBuilder('Laminas\Mvc\MvcEvent')
             ->disableOriginalConstructor()
             ->getMock();
         $this->mvcEvent->expects($this->any())

--- a/tests/ZfcUserTest/Controller/UserControllerTest.php
+++ b/tests/ZfcUserTest/Controller/UserControllerTest.php
@@ -2,14 +2,14 @@
 
 namespace ZfcUserTest\Controller;
 
-use Zend\Form\FormElementManager;
+use Laminas\Form\FormElementManager;
 use ZfcUser\Controller\RedirectCallback;
 use ZfcUser\Controller\UserController as Controller;
-use Zend\Http\Response;
-use Zend\Stdlib\Parameters;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Laminas\Http\Response;
+use Laminas\Stdlib\Parameters;
+use Laminas\ServiceManager\ServiceLocatorInterface;
 use ZfcUser\Service\User as UserService;
-use Zend\Form\Form;
+use Laminas\Form\Form;
 use ZfcUser\Options\ModuleOptions;
 use ZfcUser\Entity\User as UserIdentity;
 
@@ -44,7 +44,7 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->zfcUserAuthenticationPlugin = $this->getMock('ZfcUser\Controller\Plugin\ZfcUserAuthentication');
 
-        $pluginManager = $this->getMockBuilder('Zend\Mvc\Controller\PluginManager')
+        $pluginManager = $this->getMockBuilder('Laminas\Mvc\Controller\PluginManager')
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -117,7 +117,7 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
                 ->will($this->returnValue($redirectRoute));
         }
 
-        $redirect = $this->getMock('Zend\Mvc\Controller\Plugin\Redirect');
+        $redirect = $this->getMock('Laminas\Mvc\Controller\Plugin\Redirect');
         $redirect->expects($this->once())
             ->method('toRoute')
             ->with($redirectRoute)
@@ -127,7 +127,7 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
 
         $result = call_user_func(array($controller, $methodeName));
 
-        $this->assertInstanceOf('Zend\Http\Response', $result);
+        $this->assertInstanceOf('Laminas\Http\Response', $result);
         $this->assertSame($response, $result);
     }
 
@@ -143,7 +143,7 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
 
         $result = $controller->indexAction();
 
-        $this->assertInstanceOf('Zend\View\Model\ViewModel', $result);
+        $this->assertInstanceOf('Laminas\View\Model\ViewModel', $result);
     }
 
 
@@ -161,7 +161,7 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
         ));
 
         $flashMessenger = $this->getMock(
-            'Zend\Mvc\Plugin\FlashMessenger\FlashMessenger'
+            'Laminas\Mvc\Plugin\FlashMessenger\FlashMessenger'
         );
         $this->pluginManagerPlugins['flashMessenger']= $flashMessenger;
 
@@ -175,7 +175,7 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnSelf());
 
         $postArray = array('some', 'data');
-        $request = $this->getMock('Zend\Http\Request');
+        $request = $this->getMock('Laminas\Http\Request');
         $request->expects($this->any())
             ->method('isPost')
             ->will($this->returnValue(true));
@@ -211,7 +211,7 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
             $adapter->expects($this->once())
                 ->method('resetAdapters');
 
-            $service = $this->getMock('Zend\Authentication\AuthenticationService');
+            $service = $this->getMock('Laminas\Authentication\AuthenticationService');
             $service->expects($this->once())
                 ->method('clearIdentity');
 
@@ -226,7 +226,7 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
 
             $expectedResult = new \stdClass();
 
-            $forwardPlugin = $this->getMockBuilder('Zend\Mvc\Controller\Plugin\Forward')
+            $forwardPlugin = $this->getMockBuilder('Laminas\Mvc\Controller\Plugin\Forward')
                 ->disableOriginalConstructor()
                 ->getMock();
             $forwardPlugin->expects($this->once())
@@ -242,7 +242,7 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
             $route_url = "/user/login";
 
 
-            $redirect = $this->getMock('Zend\Mvc\Controller\Plugin\Redirect', array('toUrl'));
+            $redirect = $this->getMock('Laminas\Mvc\Controller\Plugin\Redirect', array('toUrl'));
             $redirect->expects($this->any())
                 ->method('toUrl')
                 ->with($route_url . $redirectQuery)
@@ -257,7 +257,7 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
 
 
             $response = new Response();
-            $url = $this->getMock('Zend\Mvc\Controller\Plugin\Url', array('fromRoute'));
+            $url = $this->getMock('Laminas\Mvc\Controller\Plugin\Url', array('fromRoute'));
             $url->expects($this->once())
                 ->method('fromRoute')
                 ->with($controller::ROUTE_LOGIN)
@@ -274,7 +274,7 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
         if ($isValid) {
             $this->assertSame($expectedResult, $result);
         } else {
-            $this->assertInstanceOf('Zend\Http\Response', $result);
+            $this->assertInstanceOf('Laminas\Http\Response', $result);
             $this->assertEquals($response, $result);
             $this->assertEquals($route_url . $redirectQuery, $result->getHeaders()->get('Location')->getFieldValue());
         }
@@ -290,11 +290,11 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
             'hasIdentity'=>false
         ));
 
-        $flashMessenger = $this->getMock('Zend\Mvc\Plugin\FlashMessenger\FlashMessenger');
+        $flashMessenger = $this->getMock('Laminas\Mvc\Plugin\FlashMessenger\FlashMessenger');
 
         $this->pluginManagerPlugins['flashMessenger'] = $flashMessenger;
 
-        $request = $this->getMock('Zend\Http\Request');
+        $request = $this->getMock('Laminas\Http\Request');
         $request->expects($this->once())
             ->method('isPost')
             ->will($this->returnValue(false));
@@ -354,7 +354,7 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
         $adapter->expects($this->once())
             ->method('logoutAdapters');
 
-        $service = $this->getMock('Zend\Authentication\AuthenticationService');
+        $service = $this->getMock('Laminas\Authentication\AuthenticationService');
         $service->expects($this->once())
             ->method('clearIdentity');
 
@@ -372,7 +372,7 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
 
         $result = $controller->logoutAction();
 
-        $this->assertInstanceOf('Zend\Http\Response', $result);
+        $this->assertInstanceOf('Laminas\Http\Response', $result);
         $this->assertSame($response, $result);
     }
 
@@ -391,7 +391,7 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
         $response = new Response();
         $hasRedirect = !(is_null($query) && is_null($post));
 
-        $params = $this->getMock('Zend\Mvc\Controller\Plugin\Params');
+        $params = $this->getMock('Laminas\Mvc\Controller\Plugin\Params');
         $params->expects($this->any())
             ->method('__invoke')
             ->will($this->returnSelf());
@@ -408,7 +408,7 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
         $this->pluginManagerPlugins['params'] = $params;
 
 
-        $request = $this->getMock('Zend\Http\Request');
+        $request = $this->getMock('Laminas\Http\Request');
         $this->helperMakePropertyAccessable($controller, 'request', $request);
 
 
@@ -418,7 +418,7 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
             ->with($request)
             ->will($this->returnValue($prepareResult));
 
-        $service = $this->getMock('Zend\Authentication\AuthenticationService');
+        $service = $this->getMock('Laminas\Authentication\AuthenticationService');
 
 
         $this->setUpZfcUserAuthenticationPlugin(array(
@@ -428,7 +428,7 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
         ));
 
         if (is_bool($prepareResult)) {
-            $authResult = $this->getMockBuilder('Zend\Authentication\Result')
+            $authResult = $this->getMockBuilder('Laminas\Authentication\Result')
                 ->disableOriginalConstructor()
                 ->getMock();
             $authResult->expects($this->once())
@@ -440,12 +440,12 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
                 ->with($adapter)
                 ->will($this->returnValue($authResult));
 
-            $redirect = $this->getMock('Zend\Mvc\Controller\Plugin\Redirect');
+            $redirect = $this->getMock('Laminas\Mvc\Controller\Plugin\Redirect');
             $this->pluginManagerPlugins['redirect'] = $redirect;
 
             if (!$authValid) {
                 $flashMessenger = $this->getMock(
-                    'Zend\Mvc\Plugin\FlashMessenger\FlashMessenger'
+                    'Laminas\Mvc\Plugin\FlashMessenger\FlashMessenger'
                 );
                 $this->pluginManagerPlugins['flashMessenger']= $flashMessenger;
 
@@ -468,7 +468,7 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
                     ->with('user/login' . $redirectQuery)
                     ->will($this->returnValue($response));
 
-                $url = $this->getMock('Zend\Mvc\Controller\Plugin\Url');
+                $url = $this->getMock('Laminas\Mvc\Controller\Plugin\Url');
                 $url->expects($this->once())
                     ->method('fromRoute')
                     ->with($controller::ROUTE_LOGIN)
@@ -533,13 +533,13 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
             ->method('getEnableRegistration')
             ->will($this->returnValue(true));
 
-        $request = $this->getMock('Zend\Http\Request');
+        $request = $this->getMock('Laminas\Http\Request');
         $this->helperMakePropertyAccessable($controller, 'request', $request);
 
         $userService = $this->getMock('ZfcUser\Service\User');
         $controller->setUserService($userService);
 
-        $form = $this->getMockBuilder('Zend\Form\Form')
+        $form = $this->getMockBuilder('Laminas\Form\Form')
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -559,7 +559,7 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
         }
 
 
-        $url = $this->getMock('Zend\Mvc\Controller\Plugin\Url');
+        $url = $this->getMock('Laminas\Mvc\Controller\Plugin\Url');
         $url->expects($this->at(0))
             ->method('fromRoute')
             ->with($controller::ROUTE_REGISTER)
@@ -567,7 +567,7 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->pluginManagerPlugins['url']= $url;
 
-        $prg = $this->getMock('Zend\Mvc\Plugin\Prg\PostRedirectGet');
+        $prg = $this->getMock('Laminas\Mvc\Plugin\Prg\PostRedirectGet');
         $this->pluginManagerPlugins['prg'] = $prg;
 
         $redirectQuery = $wantRedirect ? '?redirect=' . rawurlencode($redirectUrl) : '';
@@ -601,7 +601,7 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
 
 
                 $expectedResult = new \stdClass();
-                $forwardPlugin = $this->getMockBuilder('Zend\Mvc\Controller\Plugin\Forward')
+                $forwardPlugin = $this->getMockBuilder('Laminas\Mvc\Controller\Plugin\Forward')
                     ->disableOriginalConstructor()
                     ->getMock();
                 $forwardPlugin->expects($this->once())
@@ -620,7 +620,7 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
 
                 $redirectQuery = $redirectUrl ? '?redirect='. rawurlencode($redirectUrl) : '';
 
-                $redirect = $this->getMock('Zend\Mvc\Controller\Plugin\Redirect');
+                $redirect = $this->getMock('Laminas\Mvc\Controller\Plugin\Redirect');
                 $redirect->expects($this->once())
                     ->method('toUrl')
                     ->with($route_url . $redirectQuery)
@@ -673,7 +673,7 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
             $this->assertArrayHasKey('redirect', $result);
             $this->assertEquals($expectedResult, $result);
         } else {
-            $this->assertInstanceOf('Zend\Http\Response', $result);
+            $this->assertInstanceOf('Laminas\Http\Response', $result);
             $this->assertSame($response, $result);
         }
     }
@@ -692,7 +692,7 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
             'hasIdentity'=>true
         ));
 
-        $form = $this->getMockBuilder('Zend\Form\Form')
+        $form = $this->getMockBuilder('Laminas\Form\Form')
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -701,7 +701,7 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
 
 
         $flashMessenger = $this->getMock(
-            'Zend\Mvc\Plugin\FlashMessenger\FlashMessenger'
+            'Laminas\Mvc\Plugin\FlashMessenger\FlashMessenger'
         );
         $this->pluginManagerPlugins['flashMessenger']= $flashMessenger;
 
@@ -715,7 +715,7 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($status ? array('test') : array()));
 
 
-        $prg = $this->getMock('Zend\Mvc\Plugin\Prg\PostRedirectGet');
+        $prg = $this->getMock('Laminas\Mvc\Plugin\Prg\PostRedirectGet');
         $this->pluginManagerPlugins['prg'] = $prg;
 
 
@@ -754,7 +754,7 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
                         ->with(true);
 
 
-                    $redirect = $this->getMock('Zend\Mvc\Controller\Plugin\Redirect');
+                    $redirect = $this->getMock('Laminas\Mvc\Controller\Plugin\Redirect');
                     $redirect->expects($this->once())
                         ->method('toRoute')
                         ->with($controller::ROUTE_CHANGEPASSWD)
@@ -770,7 +770,7 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
         $exceptedReturn = null;
 
         if ($postRedirectGetReturn instanceof Response) {
-            $this->assertInstanceOf('Zend\Http\Response', $result);
+            $this->assertInstanceOf('Laminas\Http\Response', $result);
             $this->assertSame($postRedirectGetReturn, $result);
         } else {
             if ($postRedirectGetReturn === false) {
@@ -790,7 +790,7 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
                 $this->assertArrayHasKey('changePasswordForm', $result);
                 $this->assertEquals($exceptedReturn, $result);
             } else {
-                $this->assertInstanceOf('Zend\Http\Response', $result);
+                $this->assertInstanceOf('Laminas\Http\Response', $result);
                 $this->assertSame($response, $result);
             }
         }
@@ -806,7 +806,7 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
         $controller = $this->controller;
         $response = new Response();
         $userService = $this->getMock('ZfcUser\Service\User');
-        $authService = $this->getMock('Zend\Authentication\AuthenticationService');
+        $authService = $this->getMock('Laminas\Authentication\AuthenticationService');
         $identity = new UserIdentity();
 
         $controller->setUserService($userService);
@@ -815,7 +815,7 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
             'hasIdentity'=>true
         ));
 
-        $form = $this->getMockBuilder('Zend\Form\Form')
+        $form = $this->getMockBuilder('Laminas\Form\Form')
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -831,12 +831,12 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
         $identity->setEmail('user@example.com');
 
 
-        $requestParams = $this->getMock('Zend\Stdlib\Parameters');
+        $requestParams = $this->getMock('Laminas\Stdlib\Parameters');
         $requestParams->expects($this->once())
             ->method('set')
             ->with('identity', $identity->getEmail());
 
-        $request = $this->getMock('Zend\Http\Request');
+        $request = $this->getMock('Laminas\Http\Request');
         $request->expects($this->once())
             ->method('getPost')
             ->will($this->returnValue($requestParams));
@@ -845,7 +845,7 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
 
 
         $flashMessenger = $this->getMock(
-            'Zend\Mvc\Plugin\FlashMessenger\FlashMessenger'
+            'Laminas\Mvc\Plugin\FlashMessenger\FlashMessenger'
         );
         $this->pluginManagerPlugins['flashMessenger']= $flashMessenger;
 
@@ -859,7 +859,7 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($status ? array('test') : array()));
 
 
-        $prg = $this->getMock('Zend\Mvc\Plugin\Prg\PostRedirectGet');
+        $prg = $this->getMock('Laminas\Mvc\Plugin\Prg\PostRedirectGet');
         $this->pluginManagerPlugins['prg'] = $prg;
 
 
@@ -890,7 +890,7 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
                         ->with(true);
 
 
-                    $redirect = $this->getMock('Zend\Mvc\Controller\Plugin\Redirect');
+                    $redirect = $this->getMock('Laminas\Mvc\Controller\Plugin\Redirect');
                     $redirect->expects($this->once())
                         ->method('toRoute')
                         ->with($controller::ROUTE_CHANGEEMAIL)
@@ -910,7 +910,7 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
         $exceptedReturn = null;
 
         if ($postRedirectGetReturn instanceof Response) {
-            $this->assertInstanceOf('Zend\Http\Response', $result);
+            $this->assertInstanceOf('Laminas\Http\Response', $result);
             $this->assertSame($postRedirectGetReturn, $result);
         } else {
             if ($postRedirectGetReturn === false) {
@@ -931,7 +931,7 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
                 $this->assertArrayHasKey('changeEmailForm', $result);
                 $this->assertEquals($exceptedReturn, $result);
             } else {
-                $this->assertInstanceOf('Zend\Http\Response', $result);
+                $this->assertInstanceOf('Laminas\Http\Response', $result);
                 $this->assertSame($response, $result);
             }
         }
@@ -956,7 +956,7 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
         }
 
         if ($useServiceLocator) {
-            $serviceLocator = $this->getMock('Zend\ServiceManager\ServiceLocatorInterface');
+            $serviceLocator = $this->getMock('Laminas\ServiceManager\ServiceLocatorInterface');
             $serviceLocator->expects($this->once())
                 ->method('get')
                 ->with($serviceName)
@@ -1035,7 +1035,7 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
         $that = $this;
         $loginFormCallback[] = function ($that, $controller) {
             $flashMessenger = $that->getMock(
-                'Zend\Mvc\Plugin\FlashMessenger\FlashMessenger'
+                'Laminas\Mvc\Plugin\FlashMessenger\FlashMessenger'
             );
             $that->pluginManagerPlugins['flashMessenger']= $flashMessenger;
 
@@ -1046,7 +1046,7 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
         };
         $loginFormCallback[] = function ($that, $controller) {
             $flashMessenger = $that->getMock(
-                'Zend\Mvc\Plugin\FlashMessenger\FlashMessenger'
+                'Laminas\Mvc\Plugin\FlashMessenger\FlashMessenger'
             );
             $that->pluginManagerPlugins['flashMessenger']= $flashMessenger;
 

--- a/tests/ZfcUserTest/Factory/Form/ChangeEmailFormFactoryTest.php
+++ b/tests/ZfcUserTest/Factory/Form/ChangeEmailFormFactoryTest.php
@@ -1,8 +1,8 @@
 <?php
 namespace ZfcUserTest\Factory\Form;
 
-use Zend\Form\FormElementManager;
-use Zend\ServiceManager\ServiceManager;
+use Laminas\Form\FormElementManager;
+use Laminas\ServiceManager\ServiceManager;
 use ZfcUser\Factory\Form\ChangeEmail as ChangeEmailFactory;
 use ZfcUser\Options\ModuleOptions;
 use ZfcUser\Mapper\User as UserMapper;

--- a/tests/ZfcUserTest/Factory/Form/ChangePasswordFormFactoryTest.php
+++ b/tests/ZfcUserTest/Factory/Form/ChangePasswordFormFactoryTest.php
@@ -1,8 +1,8 @@
 <?php
 namespace ZfcUserTest\Factory\Form;
 
-use Zend\Form\FormElementManager;
-use Zend\ServiceManager\ServiceManager;
+use Laminas\Form\FormElementManager;
+use Laminas\ServiceManager\ServiceManager;
 use ZfcUser\Factory\Form\ChangePassword as ChangePasswordFactory;
 use ZfcUser\Options\ModuleOptions;
 use ZfcUser\Mapper\User as UserMapper;

--- a/tests/ZfcUserTest/Factory/Form/LoginFormFactoryTest.php
+++ b/tests/ZfcUserTest/Factory/Form/LoginFormFactoryTest.php
@@ -1,8 +1,8 @@
 <?php
 namespace ZfcUserTest\Factory\Form;
 
-use Zend\Form\FormElementManager;
-use Zend\ServiceManager\ServiceManager;
+use Laminas\Form\FormElementManager;
+use Laminas\ServiceManager\ServiceManager;
 use ZfcUser\Factory\Form\Login as LoginFactory;
 use ZfcUser\Options\ModuleOptions;
 

--- a/tests/ZfcUserTest/Factory/Form/RegisterFormFactoryTest.php
+++ b/tests/ZfcUserTest/Factory/Form/RegisterFormFactoryTest.php
@@ -1,9 +1,9 @@
 <?php
 namespace ZfcUserTest\Factory\Form;
 
-use Zend\Form\FormElementManager;
-use Zend\ServiceManager\ServiceManager;
-use Zend\Hydrator\ClassMethods;
+use Laminas\Form\FormElementManager;
+use Laminas\ServiceManager\ServiceManager;
+use Laminas\Hydrator\ClassMethods;
 use ZfcUser\Factory\Form\Register as RegisterFactory;
 use ZfcUser\Options\ModuleOptions;
 use ZfcUser\Mapper\User as UserMapper;

--- a/tests/ZfcUserTest/Form/ChangeEmailFilterTest.php
+++ b/tests/ZfcUserTest/Form/ChangeEmailFilterTest.php
@@ -23,7 +23,7 @@ class ChangeEmailFilterTest extends \PHPUnit_Framework_TestCase
 
         $validators = $inputs['identity']->getValidatorChain()->getValidators();
         $this->assertArrayHasKey('instance', $validators[0]);
-        $this->assertInstanceOf('\Zend\Validator\EmailAddress', $validators[0]['instance']);
+        $this->assertInstanceOf('\Laminas\Validator\EmailAddress', $validators[0]['instance']);
     }
 
     /**
@@ -52,7 +52,7 @@ class ChangeEmailFilterTest extends \PHPUnit_Framework_TestCase
             // test email as identity
             $validators = $identity->getValidatorChain()->getValidators();
             $this->assertArrayHasKey('instance', $validators[0]);
-            $this->assertInstanceOf('\Zend\Validator\EmailAddress', $validators[0]['instance']);
+            $this->assertInstanceOf('\Laminas\Validator\EmailAddress', $validators[0]['instance']);
         }
     }
 

--- a/tests/ZfcUserTest/Form/ChangePasswordFilterTest.php
+++ b/tests/ZfcUserTest/Form/ChangePasswordFilterTest.php
@@ -23,7 +23,7 @@ class ChangePasswordFilterTest extends \PHPUnit_Framework_TestCase
 
         $validators = $inputs['identity']->getValidatorChain()->getValidators();
         $this->assertArrayHasKey('instance', $validators[0]);
-        $this->assertInstanceOf('\Zend\Validator\EmailAddress', $validators[0]['instance']);
+        $this->assertInstanceOf('\Laminas\Validator\EmailAddress', $validators[0]['instance']);
     }
 
     /**
@@ -52,7 +52,7 @@ class ChangePasswordFilterTest extends \PHPUnit_Framework_TestCase
             // test email as identity
             $validators = $identity->getValidatorChain()->getValidators();
             $this->assertArrayHasKey('instance', $validators[0]);
-            $this->assertInstanceOf('\Zend\Validator\EmailAddress', $validators[0]['instance']);
+            $this->assertInstanceOf('\Laminas\Validator\EmailAddress', $validators[0]['instance']);
         }
     }
 

--- a/tests/ZfcUserTest/Form/LoginFilterTest.php
+++ b/tests/ZfcUserTest/Form/LoginFilterTest.php
@@ -46,6 +46,6 @@ class LoginFilterTest extends \PHPUnit_Framework_TestCase
         // test email as identity
         $validators = $identity->getValidatorChain()->getValidators();
         $this->assertArrayHasKey('instance', $validators[0]);
-        $this->assertInstanceOf('\Zend\Validator\EmailAddress', $validators[0]['instance']);
+        $this->assertInstanceOf('\Laminas\Validator\EmailAddress', $validators[0]['instance']);
     }
 }

--- a/tests/ZfcUserTest/Form/RegisterTest.php
+++ b/tests/ZfcUserTest/Form/RegisterTest.php
@@ -21,8 +21,8 @@ class RegisterTest extends \PHPUnit_Framework_TestCase
         $options->expects($this->any())
                 ->method('getUseRegistrationFormCaptcha')
                 ->will($this->returnValue($useCaptcha));
-        if ($useCaptcha && class_exists('\Zend\Captcha\AbstractAdapter')) {
-            $captcha = $this->getMockForAbstractClass('\Zend\Captcha\AbstractAdapter');
+        if ($useCaptcha && class_exists('\Laminas\Captcha\AbstractAdapter')) {
+            $captcha = $this->getMockForAbstractClass('\Laminas\Captcha\AbstractAdapter');
 
             $options->expects($this->once())
                 ->method('getFormCaptchaOptions')
@@ -83,7 +83,7 @@ class RegisterTest extends \PHPUnit_Framework_TestCase
                 ->method('getUseRegistrationFormCaptcha')
                 ->will($this->returnValue(false));
 
-        $captcha = $this->getMock('\Zend\Form\Element\Captcha');
+        $captcha = $this->getMock('\Laminas\Form\Element\Captcha');
         $form = new Form(null, $options);
 
         $form->setCaptchaElement($captcha);

--- a/tests/ZfcUserTest/Mapper/UserTest.php
+++ b/tests/ZfcUserTest/Mapper/UserTest.php
@@ -4,8 +4,8 @@ namespace ZfcUserTest\Mapper;
 
 use ZfcUser\Mapper\User as Mapper;
 use ZfcUser\Entity\User as Entity;
-use Zend\Db\ResultSet\HydratingResultSet;
-use Zend\Db\Adapter\Adapter;
+use Laminas\Db\ResultSet\HydratingResultSet;
+use Laminas\Db\Adapter\Adapter;
 use ZfcUser\Mapper\UserHydrator;
 
 class UserTest extends \PHPUnit_Framework_TestCase
@@ -13,25 +13,25 @@ class UserTest extends \PHPUnit_Framework_TestCase
     /** @var \ZfcUser\Mapper\User */
     protected $mapper;
 
-    /** @var \Zend\Db\Adapter\Adapter */
+    /** @var \Laminas\Db\Adapter\Adapter */
     protected $mockedDbAdapter;
 
-    /** @var \Zend\Db\Adapter\Adapter */
+    /** @var \Laminas\Db\Adapter\Adapter */
     protected $realAdapter = array();
 
-    /** @var \Zend\Db\Sql\Select */
+    /** @var \Laminas\Db\Sql\Select */
     protected $mockedSelect;
 
-    /** @var \Zend\Db\ResultSet\HydratingResultSet */
+    /** @var \Laminas\Db\ResultSet\HydratingResultSet */
     protected $mockedResultSet;
 
-    /** @var \Zend\Db\Sql\Sql */
+    /** @var \Laminas\Db\Sql\Sql */
     protected $mockedDbSql;
 
-    /** @var \Zend\Db\Adapter\Driver\DriverInterface */
+    /** @var \Laminas\Db\Adapter\Driver\DriverInterface */
     protected $mockedDbAdapterDriver;
 
-    /** @var \Zend\Db\Adapter\Platform\PlatformInterface */
+    /** @var \Laminas\Db\Adapter\Platform\PlatformInterface */
     protected $mockedDbAdapterPlatform;
 
     public function setUp()
@@ -44,9 +44,9 @@ class UserTest extends \PHPUnit_Framework_TestCase
 
         $this->setUpMockedAdapter();
 
-        $this->mockedSelect = $this->getMock('\Zend\Db\Sql\Select', array('where'));
+        $this->mockedSelect = $this->getMock('\Laminas\Db\Sql\Select', array('where'));
 
-        $this->mockedResultSet = $this->getMock('\Zend\Db\ResultSet\HydratingResultSet');
+        $this->mockedResultSet = $this->getMock('\Laminas\Db\ResultSet\HydratingResultSet');
 
         $this->setUpAdapter('mysql');
 //         $this->setUpAdapter('pgsql');
@@ -105,15 +105,15 @@ class UserTest extends \PHPUnit_Framework_TestCase
      */
     public function setUpMockedAdapter()
     {
-        $this->mockedDbAdapterDriver = $this->getMock('Zend\Db\Adapter\Driver\DriverInterface');
-        $this->mockedDbAdapterPlatform = $this->getMock('Zend\Db\Adapter\Platform\PlatformInterface', array());
-        $this->mockedDbAdapterStatement= $this->getMock('Zend\Db\Adapter\Driver\StatementInterface', array());
+        $this->mockedDbAdapterDriver = $this->getMock('Laminas\Db\Adapter\Driver\DriverInterface');
+        $this->mockedDbAdapterPlatform = $this->getMock('Laminas\Db\Adapter\Platform\PlatformInterface', array());
+        $this->mockedDbAdapterStatement= $this->getMock('Laminas\Db\Adapter\Driver\StatementInterface', array());
 
         $this->mockedDbAdapterPlatform->expects($this->any())
                                       ->method('getName')
                                       ->will($this->returnValue('null'));
 
-        $this->mockedDbAdapter = $this->getMockBuilder('Zend\Db\Adapter\Adapter')
+        $this->mockedDbAdapter = $this->getMockBuilder('Laminas\Db\Adapter\Adapter')
                                       ->setConstructorArgs(array(
                                           $this->mockedDbAdapterDriver,
                                           $this->mockedDbAdapterPlatform
@@ -124,7 +124,7 @@ class UserTest extends \PHPUnit_Framework_TestCase
                               ->method('getPlatform')
                               ->will($this->returnValue($this->mockedDbAdapterPlatform));
 
-        $this->mockedDbSql = $this->getMockBuilder('Zend\Db\Sql\Sql')
+        $this->mockedDbSql = $this->getMockBuilder('Laminas\Db\Sql\Sql')
                                   ->setConstructorArgs(array($this->mockedDbAdapter))
                                   ->setMethods(array('prepareStatementForSqlObject'))
                                   ->getMock();
@@ -132,7 +132,7 @@ class UserTest extends \PHPUnit_Framework_TestCase
                           ->method('prepareStatementForSqlObject')
                           ->will($this->returnValue($this->mockedDbAdapterStatement));
 
-        $this->mockedDbSqlPlatform = $this->getMockBuilder('\Zend\Db\Sql\Platform\Platform')
+        $this->mockedDbSqlPlatform = $this->getMockBuilder('\Laminas\Db\Sql\Platform\Platform')
                                           ->setConstructorArgs(array($this->mockedDbAdapter))
                                           ->getMock();
     }

--- a/tests/ZfcUserTest/Service/UserTest.php
+++ b/tests/ZfcUserTest/Service/UserTest.php
@@ -3,7 +3,7 @@
 namespace ZfcUserTest\Service;
 
 use ZfcUser\Service\User as Service;
-use Zend\Crypt\Password\Bcrypt;
+use Laminas\Crypt\Password\Bcrypt;
 
 class UserTest extends \PHPUnit_Framework_TestCase
 {
@@ -29,19 +29,19 @@ class UserTest extends \PHPUnit_Framework_TestCase
         $options = $this->getMock('ZfcUser\Options\ModuleOptions');
         $this->options = $options;
 
-        $serviceManager = $this->getMock('Zend\ServiceManager\ServiceManager');
+        $serviceManager = $this->getMock('Laminas\ServiceManager\ServiceManager');
         $this->serviceManager = $serviceManager;
 
-        $eventManager = $this->getMock('Zend\EventManager\EventManager');
+        $eventManager = $this->getMock('Laminas\EventManager\EventManager');
         $this->eventManager = $eventManager;
 
-        $formHydrator = $this->getMock('Zend\Hydrator\HydratorInterface');
+        $formHydrator = $this->getMock('Laminas\Hydrator\HydratorInterface');
         $this->formHydrator = $formHydrator;
 
         $mapper = $this->getMock('ZfcUser\Mapper\UserInterface');
         $this->mapper = $mapper;
 
-        $authService = $this->getMockBuilder('Zend\Authentication\AuthenticationService')->disableOriginalConstructor()->getMock();
+        $authService = $this->getMockBuilder('Laminas\Authentication\AuthenticationService')->disableOriginalConstructor()->getMock();
         $this->authService = $authService;
 
         $service->setOptions($options);
@@ -458,7 +458,7 @@ class UserTest extends \PHPUnit_Framework_TestCase
 
         $service = new Service;
         $service->setServiceManager($this->serviceManager);
-        $this->assertInstanceOf('Zend\Authentication\AuthenticationService', $service->getAuthService());
+        $this->assertInstanceOf('Laminas\Authentication\AuthenticationService', $service->getAuthService());
     }
 
     /**
@@ -576,7 +576,7 @@ class UserTest extends \PHPUnit_Framework_TestCase
 
         $service = new Service;
         $service->setServiceManager($this->serviceManager);
-        $this->assertInstanceOf('Zend\Hydrator\HydratorInterface', $service->getFormHydrator());
+        $this->assertInstanceOf('Laminas\Hydrator\HydratorInterface', $service->getFormHydrator());
     }
 
     /**

--- a/tests/ZfcUserTest/View/Helper/ZfcUserDisplayNameTest.php
+++ b/tests/ZfcUserTest/View/Helper/ZfcUserDisplayNameTest.php
@@ -17,7 +17,7 @@ class ZfcUserDisplayNameTest extends \PHPUnit_Framework_TestCase
         $helper = new ViewHelper;
         $this->helper = $helper;
 
-        $authService = $this->getMock('Zend\Authentication\AuthenticationService');
+        $authService = $this->getMock('Laminas\Authentication\AuthenticationService');
         $this->authService = $authService;
 
         $user = $this->getMock('ZfcUser\Entity\User');

--- a/tests/ZfcUserTest/View/Helper/ZfcUserIdentityTest.php
+++ b/tests/ZfcUserTest/View/Helper/ZfcUserIdentityTest.php
@@ -15,7 +15,7 @@ class ZfcUserIdentityTest extends \PHPUnit_Framework_TestCase
         $helper = new ViewHelper;
         $this->helper = $helper;
 
-        $authService = $this->getMock('Zend\Authentication\AuthenticationService');
+        $authService = $this->getMock('Laminas\Authentication\AuthenticationService');
         $this->authService = $authService;
 
         $helper->setAuthService($authService);

--- a/tests/ZfcUserTest/View/Helper/ZfcUserLoginWidgetTest.php
+++ b/tests/ZfcUserTest/View/Helper/ZfcUserLoginWidgetTest.php
@@ -3,7 +3,7 @@
 namespace ZfcUserTest\View\Helper;
 
 use ZfcUser\View\Helper\ZfcUserLoginWidget as ViewHelper;
-use Zend\View\Model\ViewModel;
+use Laminas\View\Model\ViewModel;
 
 class ZfcUserLoginWidgetTest extends \PHPUnit_Framework_TestCase
 {
@@ -15,7 +15,7 @@ class ZfcUserLoginWidgetTest extends \PHPUnit_Framework_TestCase
     {
         $this->helper = new ViewHelper;
 
-        $view = $this->getMock('Zend\View\Renderer\RendererInterface');
+        $view = $this->getMock('Laminas\View\Renderer\RendererInterface');
         $this->view = $view;
 
         $this->helper->setView($view);
@@ -63,7 +63,7 @@ class ZfcUserLoginWidgetTest extends \PHPUnit_Framework_TestCase
     public function testInvokeWithRender($option, $expect)
     {
         /**
-         * @var $viewModel \Zend\View\Model\ViewModels
+         * @var $viewModel \Laminas\View\Model\ViewModels
          */
         $viewModel = null;
 
@@ -76,11 +76,11 @@ class ZfcUserLoginWidgetTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->helper->__invoke($option);
 
-        $this->assertNotInstanceOf('Zend\View\Model\ViewModel', $result);
+        $this->assertNotInstanceOf('Laminas\View\Model\ViewModel', $result);
         $this->assertInternalType('string', $result);
 
 
-        $this->assertInstanceOf('Zend\View\Model\ViewModel', $viewModel);
+        $this->assertInstanceOf('Laminas\View\Model\ViewModel', $viewModel);
         foreach ($expect as $name => $value) {
             $this->assertEquals($value, $viewModel->getVariable($name, "testDefault"));
         }
@@ -96,7 +96,7 @@ class ZfcUserLoginWidgetTest extends \PHPUnit_Framework_TestCase
             'redirect' => 'zfcUser'
         ));
 
-        $this->assertInstanceOf('Zend\View\Model\ViewModel', $result);
+        $this->assertInstanceOf('Laminas\View\Model\ViewModel', $result);
         $this->assertEquals('zfcUser', $result->redirect);
     }
 

--- a/view/zfc-user/user/_form.phtml
+++ b/view/zfc-user/user/_form.phtml
@@ -1,7 +1,7 @@
 <?php echo $this->form()->openTag($form) ?>
     <dl class="zend_form">
         <?php foreach ($form as $element) : ?>
-            <?php if ($element->getLabel() != null && !$element instanceof Zend\Form\Element\Button) : ?>
+            <?php if ($element->getLabel() != null && !$element instanceof Laminas\Form\Element\Button) : ?>
                 <dt><?php echo $this->formLabel($element) ?></dt>
             <?php endif ?>
             <dd><?php echo $this->formElement($element) . $this->formElementErrors($element) ?></dd>


### PR DESCRIPTION
Possibility to configure captcha for login form.
New parameter in configuration: "use_login_form_captcha" to enable captcha in login
Captcha options are equal to registration captcha

Additionally csrf is enabled, as form is validated by isValid() function

