### PR TITLE
Added csrf tokens to all forms

### DIFF
--- a/src/ZfcUser/Form/ChangeEmail.php
+++ b/src/ZfcUser/Form/ChangeEmail.php
@@ -58,6 +58,16 @@ class ChangeEmail extends ProvidesEventsForm
             ),
         ));
 
+        $this->add([
+            'type' => '\Zend\Form\Element\Csrf',
+            'name' => 'security',
+            'options' => [
+                'csrf_options' => [
+                    'timeout' => $this->getAuthenticationOptions()->getLoginFormTimeout()
+                ]
+            ]
+        ]);
+
         $this->add(array(
             'name' => 'submit',
             'attributes' => array(

--- a/src/ZfcUser/Form/ChangePassword.php
+++ b/src/ZfcUser/Form/ChangePassword.php
@@ -59,6 +59,16 @@ class ChangePassword extends ProvidesEventsForm
             ),
         ));
 
+        $this->add([
+            'type' => '\Zend\Form\Element\Csrf',
+            'name' => 'security',
+            'options' => [
+                'csrf_options' => [
+                    'timeout' => $this->getAuthenticationOptions()->getLoginFormTimeout()
+                ]
+            ]
+        ]);
+
         $this->add(array(
             'name' => 'submit',
             'attributes' => array(

--- a/src/ZfcUser/Form/Login.php
+++ b/src/ZfcUser/Form/Login.php
@@ -56,6 +56,16 @@ class Login extends ProvidesEventsForm
         //$csrf->getValidator()->setTimeout($options->getLoginFormTimeout());
         //$this->add($csrf);
 
+        $this->add([
+            'type' => '\Zend\Form\Element\Csrf',
+            'name' => 'security',
+            'options' => [
+                'csrf_options' => [
+                    'timeout' => $this->getAuthenticationOptions()->getLoginFormTimeout()
+                ]
+            ]
+        ]);
+
         $submitElement = new Element\Button('submit');
         $submitElement
             ->setLabel('Sign In')

--- a/src/ZfcUser/Form/Register.php
+++ b/src/ZfcUser/Form/Register.php
@@ -24,6 +24,16 @@ class Register extends Base
 
         parent::__construct($name);
 
+        $this->add([
+            'type' => '\Zend\Form\Element\Csrf',
+            'name' => 'security',
+            'options' => [
+                'csrf_options' => [
+                    'timeout' => $this->getRegistrationOptions()->getUserFormTimeout()
+                ]
+            ]
+        ]);
+
         if ($this->getRegistrationOptions()->getUseRegistrationFormCaptcha()) {
             $this->add(array(
                 'name' => 'captcha',

--- a/tests/ZfcUserTest/Form/ChangeEmailTest.php
+++ b/tests/ZfcUserTest/Form/ChangeEmailTest.php
@@ -21,6 +21,7 @@ class ChangeEmailTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('newIdentity', $elements);
         $this->assertArrayHasKey('newIdentityVerify', $elements);
         $this->assertArrayHasKey('credential', $elements);
+        $this->assertArrayHasKey('security', $elements);
     }
 
     /**

--- a/tests/ZfcUserTest/Form/ChangePasswordTest.php
+++ b/tests/ZfcUserTest/Form/ChangePasswordTest.php
@@ -21,6 +21,7 @@ class ChangePasswordTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('credential', $elements);
         $this->assertArrayHasKey('newCredential', $elements);
         $this->assertArrayHasKey('newCredentialVerify', $elements);
+        $this->assertArrayHasKey('security', $elements);
     }
 
     /**

--- a/tests/ZfcUserTest/Form/LoginTest.php
+++ b/tests/ZfcUserTest/Form/LoginTest.php
@@ -23,6 +23,8 @@ class LoginTest extends \PHPUnit_Framework_TestCase
 
         $this->assertArrayHasKey('identity', $elements);
         $this->assertArrayHasKey('credential', $elements);
+        $this->assertArrayHasKey('security', $elements);
+
 
         $expectedLabel="";
         if (count($authIdentityFields) > 0) {

--- a/tests/ZfcUserTest/Form/RegisterTest.php
+++ b/tests/ZfcUserTest/Form/RegisterTest.php
@@ -39,6 +39,8 @@ class RegisterTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('email', $elements);
         $this->assertArrayHasKey('password', $elements);
         $this->assertArrayHasKey('passwordVerify', $elements);
+        $this->assertArrayHasKey('security', $elements);
+
     }
 
     public function providerTestConstruct()


### PR DESCRIPTION
Since a really really long time (since 2012!!!!) CSRF has been commented out and there was no fix until now.
The descriptions says CSRF is implemented and complete! That is simply WRONG and is a security nightmare!!

I implemented the basic CSRF tokens which take the settings from the config.
Maybe the naming of this setting(s) has to be changed because it's not only used in the login form but in all the others except the registration form.
That can be discussed and added later on. For now it would be good if anyone of the maintainer(@EvanDotPro , @weierophinney , @Danielss89 ) could merge and release a new package.
Thanks :)